### PR TITLE
refactor(domain): introduce repository interfaces and decouple use ca…

### DIFF
--- a/lib/core/di/riverpod_providers.dart
+++ b/lib/core/di/riverpod_providers.dart
@@ -16,10 +16,16 @@ import 'package:dienstplan/data/data_sources/schedule_local_data_source.dart';
 import 'package:dienstplan/data/data_sources/settings_local_data_source.dart';
 import 'package:dienstplan/data/data_sources/config_local_data_source.dart';
 
-// Repositories
-import 'package:dienstplan/data/repositories/schedule_repository.dart';
-import 'package:dienstplan/data/repositories/settings_repository.dart';
-import 'package:dienstplan/data/repositories/config_repository.dart';
+// Repositories (interfaces + implementations)
+import 'package:dienstplan/domain/repositories/schedule_repository.dart';
+import 'package:dienstplan/domain/repositories/settings_repository.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart';
+import 'package:dienstplan/data/repositories/schedule_repository.dart'
+    as data_repos;
+import 'package:dienstplan/data/repositories/settings_repository.dart'
+    as data_repos;
+import 'package:dienstplan/data/repositories/config_repository.dart'
+    as data_repos;
 
 // Use cases
 import 'package:dienstplan/domain/use_cases/get_schedules_use_case.dart';
@@ -137,20 +143,20 @@ Future<ConfigLocalDataSource> configLocalDataSource(Ref ref) async {
 @Riverpod(keepAlive: true)
 Future<ScheduleRepository> scheduleRepository(Ref ref) async {
   final DatabaseService db = await ref.watch(databaseServiceProvider.future);
-  return ScheduleRepository(db);
+  return data_repos.ScheduleRepositoryImpl(db);
 }
 
 @Riverpod(keepAlive: true)
 Future<SettingsRepository> settingsRepository(Ref ref) async {
   final DatabaseService db = await ref.watch(databaseServiceProvider.future);
-  return SettingsRepository(db);
+  return data_repos.SettingsRepositoryImpl(db);
 }
 
 @Riverpod(keepAlive: true)
 Future<ConfigRepository> configRepository(Ref ref) async {
   final ScheduleConfigService cfg =
       await ref.watch(scheduleConfigServiceProvider.future);
-  return ConfigRepository(cfg);
+  return data_repos.ConfigRepositoryImpl(cfg);
 }
 
 // Use cases

--- a/lib/core/di/riverpod_providers.g.dart
+++ b/lib/core/di/riverpod_providers.g.dart
@@ -199,7 +199,7 @@ final configLocalDataSourceProvider =
 // ignore: unused_element
 typedef ConfigLocalDataSourceRef = FutureProviderRef<ConfigLocalDataSource>;
 String _$scheduleRepositoryHash() =>
-    r'9773ea860cfab67cd21284b98f950173845aee08';
+    r'2fe0c2d57eac7ea010f25f4feee18810a96e9b9e';
 
 /// See also [scheduleRepository].
 @ProviderFor(scheduleRepository)
@@ -217,7 +217,7 @@ final scheduleRepositoryProvider = FutureProvider<ScheduleRepository>.internal(
 // ignore: unused_element
 typedef ScheduleRepositoryRef = FutureProviderRef<ScheduleRepository>;
 String _$settingsRepositoryHash() =>
-    r'20b12f8a4b818a9b4a533784ef2ee5fcd02f1a35';
+    r'9293b51bdaadc026f158b682ca7e9c1f9635bde5';
 
 /// See also [settingsRepository].
 @ProviderFor(settingsRepository)
@@ -234,7 +234,7 @@ final settingsRepositoryProvider = FutureProvider<SettingsRepository>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef SettingsRepositoryRef = FutureProviderRef<SettingsRepository>;
-String _$configRepositoryHash() => r'd01c75286832cd4ba03674afe5fdba014b54316f';
+String _$configRepositoryHash() => r'7a6c6fcd1939f701b317fae9a4ab766eb5810e21';
 
 /// See also [configRepository].
 @ProviderFor(configRepository)

--- a/lib/data/repositories/config_repository.dart
+++ b/lib/data/repositories/config_repository.dart
@@ -6,14 +6,17 @@ import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/domain/failures/result.dart';
 import 'package:dienstplan/core/errors/exception_mapper.dart';
 import 'package:dienstplan/domain/failures/failure.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart'
+    as domain_repo;
 
-class ConfigRepository {
+class ConfigRepositoryImpl implements domain_repo.ConfigRepository {
   final ScheduleConfigService _configService;
   final ExceptionMapper _exceptionMapper;
 
-  ConfigRepository(this._configService, {ExceptionMapper? exceptionMapper})
+  ConfigRepositoryImpl(this._configService, {ExceptionMapper? exceptionMapper})
       : _exceptionMapper = exceptionMapper ?? const ExceptionMapper();
 
+  @override
   Future<List<domain.DutyScheduleConfig>> getConfigs() async {
     try {
       AppLogger.i('ConfigRepository: Getting configs');
@@ -28,6 +31,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<Result<List<domain.DutyScheduleConfig>>> getConfigsSafe() async {
     try {
       final configs = await getConfigs();
@@ -38,6 +42,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<domain.DutyScheduleConfig?> getDefaultConfig() async {
     try {
       AppLogger.i('ConfigRepository: Getting default config');
@@ -53,6 +58,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<Result<domain.DutyScheduleConfig?>> getDefaultConfigSafe() async {
     try {
       final config = await getDefaultConfig();
@@ -63,6 +69,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<void> saveConfig(domain.DutyScheduleConfig config) async {
     try {
       AppLogger.i('ConfigRepository: Saving config: ${config.name}');
@@ -75,6 +82,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<Result<void>> saveConfigSafe(domain.DutyScheduleConfig config) async {
     try {
       await saveConfig(config);
@@ -85,6 +93,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<void> setDefaultConfig(domain.DutyScheduleConfig config) async {
     try {
       AppLogger.i('ConfigRepository: Setting default config: ${config.name}');
@@ -98,6 +107,7 @@ class ConfigRepository {
     }
   }
 
+  @override
   Future<Result<void>> setDefaultConfigSafe(
       domain.DutyScheduleConfig config) async {
     try {

--- a/lib/data/repositories/schedule_repository.dart
+++ b/lib/data/repositories/schedule_repository.dart
@@ -1,5 +1,7 @@
 import 'package:dienstplan/domain/entities/schedule.dart';
 import 'package:dienstplan/domain/entities/duty_type.dart';
+import 'package:dienstplan/domain/repositories/schedule_repository.dart'
+    as domain_repo;
 import 'package:dienstplan/data/services/database_service.dart';
 import 'package:dienstplan/data/models/mappers/schedule_mapper.dart' as mapper;
 import 'package:dienstplan/core/utils/logger.dart';
@@ -7,13 +9,15 @@ import 'package:dienstplan/domain/failures/result.dart';
 import 'package:dienstplan/core/errors/exception_mapper.dart';
 import 'package:dienstplan/domain/failures/failure.dart';
 
-class ScheduleRepository {
+class ScheduleRepositoryImpl implements domain_repo.ScheduleRepository {
   final DatabaseService _databaseService;
   final ExceptionMapper _exceptionMapper;
 
-  ScheduleRepository(this._databaseService, {ExceptionMapper? exceptionMapper})
+  ScheduleRepositoryImpl(this._databaseService,
+      {ExceptionMapper? exceptionMapper})
       : _exceptionMapper = exceptionMapper ?? const ExceptionMapper();
 
+  @override
   Future<List<Schedule>> getSchedules() async {
     try {
       AppLogger.i('ScheduleRepository: Getting all schedules');
@@ -28,6 +32,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<Result<List<Schedule>>> getSchedulesSafe() async {
     try {
       final result = await getSchedules();
@@ -38,6 +43,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<List<Schedule>> getSchedulesForDateRange({
     required DateTime start,
     required DateTime end,
@@ -59,6 +65,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<Result<List<Schedule>>> getSchedulesForDateRangeSafe({
     required DateTime start,
     required DateTime end,
@@ -77,6 +84,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<void> saveSchedules(List<Schedule> schedules) async {
     try {
       AppLogger.i('ScheduleRepository: Saving ${schedules.length} schedules');
@@ -89,6 +97,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<Result<void>> saveSchedulesSafe(List<Schedule> schedules) async {
     try {
       await saveSchedules(schedules);
@@ -99,6 +108,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<void> clearSchedules() async {
     try {
       AppLogger.i('ScheduleRepository: Clearing all schedules');
@@ -111,6 +121,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<Result<void>> clearSchedulesSafe() async {
     try {
       await clearSchedules();
@@ -121,6 +132,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<List<DutyType>> getDutyTypes({required String configName}) async {
     try {
       AppLogger.i(
@@ -143,6 +155,7 @@ class ScheduleRepository {
     }
   }
 
+  @override
   Future<Result<List<DutyType>>> getDutyTypesSafe(
       {required String configName}) async {
     try {

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -5,14 +5,18 @@ import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/domain/failures/result.dart';
 import 'package:dienstplan/core/errors/exception_mapper.dart';
 import 'package:dienstplan/domain/failures/failure.dart';
+import 'package:dienstplan/domain/repositories/settings_repository.dart'
+    as domain_repo;
 
-class SettingsRepository {
+class SettingsRepositoryImpl implements domain_repo.SettingsRepository {
   final DatabaseService _databaseService;
   final ExceptionMapper _exceptionMapper;
 
-  SettingsRepository(this._databaseService, {ExceptionMapper? exceptionMapper})
+  SettingsRepositoryImpl(this._databaseService,
+      {ExceptionMapper? exceptionMapper})
       : _exceptionMapper = exceptionMapper ?? const ExceptionMapper();
 
+  @override
   Future<domain.Settings?> getSettings() async {
     try {
       AppLogger.i('SettingsRepository: Getting settings');
@@ -29,6 +33,7 @@ class SettingsRepository {
     }
   }
 
+  @override
   Future<Result<domain.Settings?>> getSettingsSafe() async {
     try {
       final settings = await getSettings();
@@ -39,6 +44,7 @@ class SettingsRepository {
     }
   }
 
+  @override
   Future<void> saveSettings(domain.Settings settings) async {
     try {
       AppLogger.i('SettingsRepository: Saving settings');
@@ -51,6 +57,7 @@ class SettingsRepository {
     }
   }
 
+  @override
   Future<Result<void>> saveSettingsSafe(domain.Settings settings) async {
     try {
       await saveSettings(settings);
@@ -61,6 +68,7 @@ class SettingsRepository {
     }
   }
 
+  @override
   Future<void> clearSettings() async {
     try {
       AppLogger.i('SettingsRepository: Clearing settings');
@@ -72,6 +80,7 @@ class SettingsRepository {
     }
   }
 
+  @override
   Future<Result<void>> clearSettingsSafe() async {
     try {
       await clearSettings();

--- a/lib/domain/repositories/config_repository.dart
+++ b/lib/domain/repositories/config_repository.dart
@@ -1,0 +1,16 @@
+import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
+import 'package:dienstplan/domain/failures/result.dart';
+
+abstract class ConfigRepository {
+  Future<List<DutyScheduleConfig>> getConfigs();
+  Future<Result<List<DutyScheduleConfig>>> getConfigsSafe();
+
+  Future<DutyScheduleConfig?> getDefaultConfig();
+  Future<Result<DutyScheduleConfig?>> getDefaultConfigSafe();
+
+  Future<void> saveConfig(DutyScheduleConfig config);
+  Future<Result<void>> saveConfigSafe(DutyScheduleConfig config);
+
+  Future<void> setDefaultConfig(DutyScheduleConfig config);
+  Future<Result<void>> setDefaultConfigSafe(DutyScheduleConfig config);
+}

--- a/lib/domain/repositories/schedule_repository.dart
+++ b/lib/domain/repositories/schedule_repository.dart
@@ -1,0 +1,29 @@
+import 'package:dienstplan/domain/entities/duty_type.dart';
+import 'package:dienstplan/domain/entities/schedule.dart';
+import 'package:dienstplan/domain/failures/result.dart';
+
+abstract class ScheduleRepository {
+  Future<List<Schedule>> getSchedules();
+  Future<Result<List<Schedule>>> getSchedulesSafe();
+
+  Future<List<Schedule>> getSchedulesForDateRange({
+    required DateTime start,
+    required DateTime end,
+    String? configName,
+  });
+
+  Future<Result<List<Schedule>>> getSchedulesForDateRangeSafe({
+    required DateTime start,
+    required DateTime end,
+    String? configName,
+  });
+
+  Future<void> saveSchedules(List<Schedule> schedules);
+  Future<Result<void>> saveSchedulesSafe(List<Schedule> schedules);
+
+  Future<void> clearSchedules();
+  Future<Result<void>> clearSchedulesSafe();
+
+  Future<List<DutyType>> getDutyTypes({required String configName});
+  Future<Result<List<DutyType>>> getDutyTypesSafe({required String configName});
+}

--- a/lib/domain/repositories/settings_repository.dart
+++ b/lib/domain/repositories/settings_repository.dart
@@ -1,0 +1,13 @@
+import 'package:dienstplan/domain/entities/settings.dart';
+import 'package:dienstplan/domain/failures/result.dart';
+
+abstract class SettingsRepository {
+  Future<Settings?> getSettings();
+  Future<Result<Settings?>> getSettingsSafe();
+
+  Future<void> saveSettings(Settings settings);
+  Future<Result<void>> saveSettingsSafe(Settings settings);
+
+  Future<void> clearSettings();
+  Future<Result<void>> clearSettingsSafe();
+}

--- a/lib/domain/use_cases/generate_schedules_use_case.dart
+++ b/lib/domain/use_cases/generate_schedules_use_case.dart
@@ -1,7 +1,7 @@
 import 'package:dienstplan/domain/entities/schedule.dart';
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
-import 'package:dienstplan/data/repositories/schedule_repository.dart';
-import 'package:dienstplan/data/repositories/config_repository.dart';
+import 'package:dienstplan/domain/repositories/schedule_repository.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/core/constants/schedule_constants.dart';
 import 'package:dienstplan/shared/utils/schedule_isolate.dart';

--- a/lib/domain/use_cases/get_configs_use_case.dart
+++ b/lib/domain/use_cases/get_configs_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
-import 'package:dienstplan/data/repositories/config_repository.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 
 class GetConfigsUseCase {

--- a/lib/domain/use_cases/get_schedules_use_case.dart
+++ b/lib/domain/use_cases/get_schedules_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/schedule.dart';
-import 'package:dienstplan/data/repositories/schedule_repository.dart';
+import 'package:dienstplan/domain/repositories/schedule_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/domain/failures/result.dart';
 import 'package:dienstplan/core/errors/exception_mapper.dart';

--- a/lib/domain/use_cases/get_settings_use_case.dart
+++ b/lib/domain/use_cases/get_settings_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/settings.dart';
-import 'package:dienstplan/data/repositories/settings_repository.dart';
+import 'package:dienstplan/domain/repositories/settings_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/core/cache/settings_cache.dart';
 import 'package:dienstplan/domain/failures/result.dart';

--- a/lib/domain/use_cases/load_default_config_use_case.dart
+++ b/lib/domain/use_cases/load_default_config_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
-import 'package:dienstplan/data/repositories/config_repository.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 
 class LoadDefaultConfigUseCase {

--- a/lib/domain/use_cases/reset_settings_use_case.dart
+++ b/lib/domain/use_cases/reset_settings_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/settings.dart';
-import 'package:dienstplan/data/repositories/settings_repository.dart';
+import 'package:dienstplan/domain/repositories/settings_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:dienstplan/core/cache/settings_cache.dart';

--- a/lib/domain/use_cases/save_settings_use_case.dart
+++ b/lib/domain/use_cases/save_settings_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/settings.dart';
-import 'package:dienstplan/data/repositories/settings_repository.dart';
+import 'package:dienstplan/domain/repositories/settings_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/core/cache/settings_cache.dart';
 import 'package:dienstplan/domain/failures/result.dart';

--- a/lib/domain/use_cases/set_active_config_use_case.dart
+++ b/lib/domain/use_cases/set_active_config_use_case.dart
@@ -1,5 +1,5 @@
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
-import 'package:dienstplan/data/repositories/config_repository.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/domain/failures/result.dart';
 import 'package:dienstplan/core/errors/exception_mapper.dart';

--- a/lib/presentation/state/schedule/schedule_notifier.g.dart
+++ b/lib/presentation/state/schedule/schedule_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'schedule_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$scheduleNotifierHash() => r'2b3c35c4d6a06b04ebfec9bde273882d12a11969';
+String _$scheduleNotifierHash() => r'32a3eaadda48b252de33d6a1077911540c9f6076';
 
 /// See also [ScheduleNotifier].
 @ProviderFor(ScheduleNotifier)


### PR DESCRIPTION
…ses from data layer

- Add abstract repository interfaces under lib/domain/repositories (ScheduleRepository, SettingsRepository, ConfigRepository)
- Implement interfaces in data layer as *RepositoryImpl classes
- Update all use cases to depend on domain interfaces (imports and types)
- Adjust Riverpod providers to expose interfaces and construct data implementations
- Regenerate Riverpod outputs via build_runner
- No functional behavior changes intended

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Context
<!-- Add any other context about the pull request here --> 