### PR TITLE
fix: replace GetIt/Provider with Riverpod DI and state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ A modern, cross-platform mobile application designed specifically for police off
 
 ### 🏗 Technical Features
 - **Clean Architecture**: Separation of concerns with domain, data, and presentation layers
-- **Dependency Injection**: GetIt-based service locator for testable components
-- **State Management**: Provider pattern with ChangeNotifier for reactive UI
+- **Dependency Injection**: Riverpod-based providers for testable and composable components
+- **State Management**: Riverpod (AsyncNotifier/codegen) with Freezed unions for robust UI states
 - **Database Migration**: Automatic schema updates with user notifications
 - **Error Handling**: Comprehensive error tracking and user-friendly error messages
 
@@ -163,19 +163,19 @@ flutter build apk --release
 ```
 
 ### Key Dependencies
-- **State Management**: `provider: ^6.1.1`
-- **Dependency Injection**: `get_it: ^8.0.3`
-- **Database**: `sqflite: ^2.3.0`
-- **Calendar**: `table_calendar: ^3.0.9`
+- **State Management**: `flutter_riverpod: ^2.6.1`, `riverpod_annotation: ^2.6.1`, `freezed_annotation: ^3.1.0`
+- **Dependency Injection**: via Riverpod providers (no separate service locator)
+- **Database**: `sqflite: ^2.4.2`
+- **Calendar**: `table_calendar: ^3.2.0`
 - **Localization**: `flutter_localizations`
-- **Error Tracking**: `sentry_flutter: ^9.4.0`
+- **Error Tracking**: `sentry_flutter: ^9.6.0`
 
 ### Architecture Patterns
 - **Clean Architecture**: Separation of concerns with clear layer boundaries
 - **Repository Pattern**: Abstract data access with concrete implementations
 - **Use Case Pattern**: Business logic encapsulation
-- **Provider Pattern**: State management with ChangeNotifier
-- **Dependency Injection**: Service locator pattern with GetIt
+- **Riverpod**: State management and dependency injection via providers
+- **Dependency Injection**: Implemented with Riverpod providers (no service locator)
 
 ---
 

--- a/lib/core/constants/database_constants.dart
+++ b/lib/core/constants/database_constants.dart
@@ -1,3 +1,3 @@
 // Database constants
 
-const int kDatabaseCurrentVersion = 7;
+const int kDatabaseCurrentVersion = 8;

--- a/lib/core/di/riverpod_providers.dart
+++ b/lib/core/di/riverpod_providers.dart
@@ -39,6 +39,7 @@ import 'package:dienstplan/domain/use_cases/load_default_config_use_case.dart';
 import 'package:dienstplan/domain/services/schedule_merge_service.dart';
 import 'package:dienstplan/domain/policies/date_range_policy.dart';
 import 'package:dienstplan/domain/use_cases/ensure_month_schedules_use_case.dart';
+import 'package:dienstplan/domain/entities/settings.dart';
 
 part 'riverpod_providers.g.dart';
 
@@ -82,9 +83,20 @@ Stream<Locale> currentLocale(Ref ref) async* {
 }
 
 @Riverpod(keepAlive: true)
-ThemeMode themeMode(Ref ref) {
-  // TODO: read persisted theme setting when available
-  return ThemeMode.system;
+Future<ThemeMode> themeMode(Ref ref) async {
+  final getSettings = await ref.watch(getSettingsUseCaseProvider.future);
+  final settings = await getSettings.execute();
+  switch (settings?.themePreference) {
+    case ThemePreference.light:
+      return ThemeMode.light;
+    case ThemePreference.dark:
+      // Temporary override: dark not implemented -> use light for now
+      return ThemeMode.light;
+    case ThemePreference.system:
+    case null:
+      // Temporary override: system not implemented -> use light for now
+      return ThemeMode.light;
+  }
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/core/di/riverpod_providers.g.dart
+++ b/lib/core/di/riverpod_providers.g.dart
@@ -76,11 +76,11 @@ final currentLocaleProvider = StreamProvider<Locale>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef CurrentLocaleRef = StreamProviderRef<Locale>;
-String _$themeModeHash() => r'2f59cd95587745bfd1801103b5d444333cada6c5';
+String _$themeModeHash() => r'a87e10d56412bf7af2796455948e0293133e38fe';
 
 /// See also [themeMode].
 @ProviderFor(themeMode)
-final themeModeProvider = Provider<ThemeMode>.internal(
+final themeModeProvider = FutureProvider<ThemeMode>.internal(
   themeMode,
   name: r'themeModeProvider',
   debugGetCreateSourceHash:
@@ -91,7 +91,7 @@ final themeModeProvider = Provider<ThemeMode>.internal(
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef ThemeModeRef = ProviderRef<ThemeMode>;
+typedef ThemeModeRef = FutureProviderRef<ThemeMode>;
 String _$appThemeHash() => r'a7b7c1924a855c4d99996bc985d648ae449774aa';
 
 /// See also [appTheme].

--- a/lib/core/l10n/app_de.arb
+++ b/lib/core/l10n/app_de.arb
@@ -367,6 +367,26 @@
   "@app": {
     "description": "Title for general app settings section"
   },
+  "themeMode": "Design",
+  "@themeMode": {
+    "description": "Label for theme mode selector"
+  },
+  "themeModeLight": "Hell",
+  "@themeModeLight": {
+    "description": "Light theme option"
+  },
+  "themeModeDark": "Dunkel",
+  "@themeModeDark": {
+    "description": "Dark theme option"
+  },
+  "themeModeSystem": "System",
+  "@themeModeSystem": {
+    "description": "System theme option"
+  },
+  "darkModeNotAvailableYet": "Dunkelmodus ist noch nicht implementiert",
+  "@darkModeNotAvailableYet": {
+    "description": "SnackBar text shown when choosing a non-light theme"
+  },
   "legal": "Rechtliches",
   "@legal": {
     "description": "Title for legal section"

--- a/lib/core/l10n/app_en.arb
+++ b/lib/core/l10n/app_en.arb
@@ -363,6 +363,26 @@
   "@app": {
     "description": "Title for general app settings section"
   },
+  "themeMode": "Theme",
+  "@themeMode": {
+    "description": "Label for theme mode selector"
+  },
+  "themeModeLight": "Light",
+  "@themeModeLight": {
+    "description": "Light theme option"
+  },
+  "themeModeDark": "Dark",
+  "@themeModeDark": {
+    "description": "Dark theme option"
+  },
+  "themeModeSystem": "System",
+  "@themeModeSystem": {
+    "description": "System theme option"
+  },
+  "darkModeNotAvailableYet": "Dark mode is not implemented yet",
+  "@darkModeNotAvailableYet": {
+    "description": "SnackBar text shown when choosing a non-light theme"
+  },
   "legal": "Legal",
   "@legal": {
     "description": "Title for legal section"

--- a/lib/core/l10n/app_localizations.dart
+++ b/lib/core/l10n/app_localizations.dart
@@ -632,6 +632,36 @@ abstract class AppLocalizations {
   /// **'General'**
   String get app;
 
+  /// Label for theme mode selector
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get themeMode;
+
+  /// Light theme option
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get themeModeLight;
+
+  /// Dark theme option
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get themeModeDark;
+
+  /// System theme option
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get themeModeSystem;
+
+  /// SnackBar text shown when choosing a non-light theme
+  ///
+  /// In en, this message translates to:
+  /// **'Dark mode is not implemented yet'**
+  String get darkModeNotAvailableYet;
+
   /// Title for legal section
   ///
   /// In en, this message translates to:

--- a/lib/core/l10n/app_localizations_de.dart
+++ b/lib/core/l10n/app_localizations_de.dart
@@ -287,6 +287,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get app => 'Allgemein';
 
   @override
+  String get themeMode => 'Design';
+
+  @override
+  String get themeModeLight => 'Hell';
+
+  @override
+  String get themeModeDark => 'Dunkel';
+
+  @override
+  String get themeModeSystem => 'System';
+
+  @override
+  String get darkModeNotAvailableYet =>
+      'Dunkelmodus ist noch nicht implementiert';
+
+  @override
   String get legal => 'Rechtliches';
 
   @override

--- a/lib/core/l10n/app_localizations_en.dart
+++ b/lib/core/l10n/app_localizations_en.dart
@@ -287,6 +287,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get app => 'General';
 
   @override
+  String get themeMode => 'Theme';
+
+  @override
+  String get themeModeLight => 'Light';
+
+  @override
+  String get themeModeDark => 'Dark';
+
+  @override
+  String get themeModeSystem => 'System';
+
+  @override
+  String get darkModeNotAvailableYet => 'Dark mode is not implemented yet';
+
+  @override
   String get legal => 'Legal';
 
   @override

--- a/lib/data/models/settings.dart
+++ b/lib/data/models/settings.dart
@@ -1,4 +1,5 @@
 import 'package:table_calendar/table_calendar.dart';
+import 'package:flutter/material.dart';
 
 class Settings {
   final CalendarFormat calendarFormat;
@@ -6,6 +7,7 @@ class Settings {
   final String? selectedDutyGroup;
   final String? myDutyGroup;
   final String? activeConfigName;
+  final ThemeMode? themeMode;
 
   const Settings({
     required this.calendarFormat,
@@ -13,6 +15,7 @@ class Settings {
     this.selectedDutyGroup,
     this.myDutyGroup,
     this.activeConfigName,
+    this.themeMode,
   });
 
   factory Settings.fromMap(Map<String, dynamic> map) {
@@ -25,6 +28,7 @@ class Settings {
       selectedDutyGroup: map['selected_duty_group'] as String?,
       myDutyGroup: map['my_duty_group'] as String?,
       activeConfigName: map['active_config_name'] as String?,
+      themeMode: _parseThemeMode(map['theme_mode'] as String?),
     );
   }
 
@@ -35,6 +39,7 @@ class Settings {
       if (selectedDutyGroup != null) 'selected_duty_group': selectedDutyGroup,
       if (myDutyGroup != null) 'my_duty_group': myDutyGroup,
       if (activeConfigName != null) 'active_config_name': activeConfigName,
+      if (themeMode != null) 'theme_mode': themeMode!.name,
     };
   }
 
@@ -44,6 +49,7 @@ class Settings {
     String? selectedDutyGroup,
     String? myDutyGroup,
     String? activeConfigName,
+    ThemeMode? themeMode,
   }) {
     return Settings(
       calendarFormat: calendarFormat ?? this.calendarFormat,
@@ -51,12 +57,13 @@ class Settings {
       selectedDutyGroup: selectedDutyGroup ?? this.selectedDutyGroup,
       myDutyGroup: myDutyGroup ?? this.myDutyGroup,
       activeConfigName: activeConfigName ?? this.activeConfigName,
+      themeMode: themeMode ?? this.themeMode,
     );
   }
 
   @override
   String toString() {
-    return 'Settings(calendarFormat: $calendarFormat, language: $language, selectedDutyGroup: $selectedDutyGroup, myDutyGroup: $myDutyGroup, activeConfigName: $activeConfigName)';
+    return 'Settings(calendarFormat: $calendarFormat, language: $language, selectedDutyGroup: $selectedDutyGroup, myDutyGroup: $myDutyGroup, activeConfigName: $activeConfigName, themeMode: ${themeMode?.name})';
   }
 
   @override
@@ -67,7 +74,8 @@ class Settings {
         other.language == language &&
         other.selectedDutyGroup == selectedDutyGroup &&
         other.myDutyGroup == myDutyGroup &&
-        other.activeConfigName == activeConfigName;
+        other.activeConfigName == activeConfigName &&
+        other.themeMode == themeMode;
   }
 
   @override
@@ -76,6 +84,21 @@ class Settings {
         language.hashCode ^
         selectedDutyGroup.hashCode ^
         myDutyGroup.hashCode ^
-        activeConfigName.hashCode;
+        activeConfigName.hashCode ^
+        themeMode.hashCode;
+  }
+
+  static ThemeMode? _parseThemeMode(String? value) {
+    if (value == null) return null;
+    switch (value) {
+      case 'system':
+        return ThemeMode.system;
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      default:
+        return null;
+    }
   }
 }

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -7,6 +7,7 @@ import 'package:dienstplan/core/errors/exception_mapper.dart';
 import 'package:dienstplan/domain/failures/failure.dart';
 import 'package:dienstplan/domain/repositories/settings_repository.dart'
     as domain_repo;
+import 'package:flutter/material.dart';
 
 class SettingsRepositoryImpl implements domain_repo.SettingsRepository {
   final DatabaseService _databaseService;
@@ -98,6 +99,7 @@ class SettingsRepositoryImpl implements domain_repo.SettingsRepository {
       selectedDutyGroup: s.selectedDutyGroup,
       myDutyGroup: s.myDutyGroup,
       activeConfigName: s.activeConfigName,
+      themePreference: _mapThemeModeToPreference(s.themeMode),
     );
   }
 
@@ -108,6 +110,33 @@ class SettingsRepositoryImpl implements domain_repo.SettingsRepository {
       selectedDutyGroup: s.selectedDutyGroup,
       myDutyGroup: s.myDutyGroup,
       activeConfigName: s.activeConfigName,
+      themeMode: _mapPreferenceToThemeMode(s.themePreference),
     );
+  }
+
+  ThemeMode? _mapPreferenceToThemeMode(domain.ThemePreference? pref) {
+    switch (pref) {
+      case domain.ThemePreference.system:
+        return ThemeMode.system;
+      case domain.ThemePreference.light:
+        return ThemeMode.light;
+      case domain.ThemePreference.dark:
+        return ThemeMode.dark;
+      default:
+        return null;
+    }
+  }
+
+  domain.ThemePreference? _mapThemeModeToPreference(ThemeMode? mode) {
+    switch (mode) {
+      case ThemeMode.system:
+        return domain.ThemePreference.system;
+      case ThemeMode.light:
+        return domain.ThemePreference.light;
+      case ThemeMode.dark:
+        return domain.ThemePreference.dark;
+      default:
+        return null;
+    }
   }
 }

--- a/lib/data/services/database_service.dart
+++ b/lib/data/services/database_service.dart
@@ -69,6 +69,7 @@ class DatabaseService {
         selected_duty_group TEXT,
         my_duty_group TEXT,
         active_config_name TEXT,
+        theme_mode TEXT,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
@@ -138,6 +139,9 @@ class DatabaseService {
       }
       if (oldVersion < 7) {
         await _migrateToVersion7(txn);
+      }
+      if (oldVersion < 8) {
+        await _migrateToVersion8(txn);
       }
     });
   }
@@ -289,6 +293,19 @@ class DatabaseService {
     } catch (e, stackTrace) {
       AppLogger.e('Error during migration to version 7', e, stackTrace);
       rethrow;
+    }
+  }
+
+  Future<void> _migrateToVersion8(DatabaseExecutor db) async {
+    try {
+      AppLogger.i('Migrating to version 8: Add theme_mode to settings');
+      await db.execute('''
+        ALTER TABLE settings ADD COLUMN theme_mode TEXT
+      ''');
+      AppLogger.i('Successfully migrated to version 8: theme_mode added');
+    } catch (e, stackTrace) {
+      // Column might already exist if user reinstalled or partial migration
+      AppLogger.e('Error during migration to version 8', e, stackTrace);
     }
   }
 

--- a/lib/domain/entities/settings.dart
+++ b/lib/domain/entities/settings.dart
@@ -1,81 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:table_calendar/table_calendar.dart';
 
-class Settings {
-  final CalendarFormat calendarFormat;
-  final String? language;
-  final String? selectedDutyGroup;
-  final String? myDutyGroup;
-  final String? activeConfigName;
+part 'settings.freezed.dart';
 
-  const Settings({
-    required this.calendarFormat,
-    this.language,
-    this.selectedDutyGroup,
-    this.myDutyGroup,
-    this.activeConfigName,
-  });
+enum ThemePreference { system, light, dark }
 
-  factory Settings.fromMap(Map<String, dynamic> map) {
-    return Settings(
-      calendarFormat: CalendarFormat.values.firstWhere(
-        (format) => format.name == map['calendar_format'],
-        orElse: () => CalendarFormat.month,
-      ),
-      language: map['language'] as String?,
-      selectedDutyGroup: map['selected_duty_group'] as String?,
-      myDutyGroup: map['my_duty_group'] as String?,
-      activeConfigName: map['active_config_name'] as String?,
-    );
-  }
-
-  Map<String, dynamic> toMap() {
-    return {
-      'calendar_format': calendarFormat.name,
-      if (language != null) 'language': language,
-      if (selectedDutyGroup != null) 'selected_duty_group': selectedDutyGroup,
-      if (myDutyGroup != null) 'my_duty_group': myDutyGroup,
-      if (activeConfigName != null) 'active_config_name': activeConfigName,
-    };
-  }
-
-  Settings copyWith({
-    CalendarFormat? calendarFormat,
+@freezed
+abstract class Settings with _$Settings {
+  const factory Settings({
+    required CalendarFormat calendarFormat,
     String? language,
     String? selectedDutyGroup,
     String? myDutyGroup,
     String? activeConfigName,
-  }) {
-    return Settings(
-      calendarFormat: calendarFormat ?? this.calendarFormat,
-      language: language ?? this.language,
-      selectedDutyGroup: selectedDutyGroup ?? this.selectedDutyGroup,
-      myDutyGroup: myDutyGroup ?? this.myDutyGroup,
-      activeConfigName: activeConfigName ?? this.activeConfigName,
-    );
-  }
+    ThemePreference? themePreference,
+  }) = _Settings;
 
-  @override
-  String toString() {
-    return 'Settings(calendarFormat: $calendarFormat, language: $language, selectedDutyGroup: $selectedDutyGroup, myDutyGroup: $myDutyGroup, activeConfigName: $activeConfigName)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    return other is Settings &&
-        other.calendarFormat == calendarFormat &&
-        other.language == language &&
-        other.selectedDutyGroup == selectedDutyGroup &&
-        other.myDutyGroup == myDutyGroup &&
-        other.activeConfigName == activeConfigName;
-  }
-
-  @override
-  int get hashCode {
-    return calendarFormat.hashCode ^
-        language.hashCode ^
-        selectedDutyGroup.hashCode ^
-        myDutyGroup.hashCode ^
-        activeConfigName.hashCode;
-  }
+  const Settings._();
 }

--- a/lib/domain/entities/settings.freezed.dart
+++ b/lib/domain/entities/settings.freezed.dart
@@ -3,7 +3,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-part of 'settings_ui_state.dart';
+part of 'settings.dart';
 
 // **************************************************************************
 // FreezedGenerator
@@ -13,114 +13,103 @@ part of 'settings_ui_state.dart';
 T _$identity<T>(T value) => value;
 
 /// @nodoc
-mixin _$SettingsUiState {
-  bool get isLoading;
-  String? get error;
+mixin _$Settings {
+  CalendarFormat get calendarFormat;
   String? get language;
-  CalendarFormat? get calendarFormat;
-  String? get activeConfigName;
+  String? get selectedDutyGroup;
   String? get myDutyGroup;
+  String? get activeConfigName;
   ThemePreference? get themePreference;
 
-  /// Create a copy of SettingsUiState
+  /// Create a copy of Settings
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
-  $SettingsUiStateCopyWith<SettingsUiState> get copyWith =>
-      _$SettingsUiStateCopyWithImpl<SettingsUiState>(
-          this as SettingsUiState, _$identity);
+  $SettingsCopyWith<Settings> get copyWith =>
+      _$SettingsCopyWithImpl<Settings>(this as Settings, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is SettingsUiState &&
-            (identical(other.isLoading, isLoading) ||
-                other.isLoading == isLoading) &&
-            (identical(other.error, error) || other.error == error) &&
-            (identical(other.language, language) ||
-                other.language == language) &&
+            other is Settings &&
             (identical(other.calendarFormat, calendarFormat) ||
                 other.calendarFormat == calendarFormat) &&
-            (identical(other.activeConfigName, activeConfigName) ||
-                other.activeConfigName == activeConfigName) &&
+            (identical(other.language, language) ||
+                other.language == language) &&
+            (identical(other.selectedDutyGroup, selectedDutyGroup) ||
+                other.selectedDutyGroup == selectedDutyGroup) &&
             (identical(other.myDutyGroup, myDutyGroup) ||
                 other.myDutyGroup == myDutyGroup) &&
+            (identical(other.activeConfigName, activeConfigName) ||
+                other.activeConfigName == activeConfigName) &&
             (identical(other.themePreference, themePreference) ||
                 other.themePreference == themePreference));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, isLoading, error, language,
-      calendarFormat, activeConfigName, myDutyGroup, themePreference);
+  int get hashCode => Object.hash(runtimeType, calendarFormat, language,
+      selectedDutyGroup, myDutyGroup, activeConfigName, themePreference);
 
   @override
   String toString() {
-    return 'SettingsUiState(isLoading: $isLoading, error: $error, language: $language, calendarFormat: $calendarFormat, activeConfigName: $activeConfigName, myDutyGroup: $myDutyGroup, themePreference: $themePreference)';
+    return 'Settings(calendarFormat: $calendarFormat, language: $language, selectedDutyGroup: $selectedDutyGroup, myDutyGroup: $myDutyGroup, activeConfigName: $activeConfigName, themePreference: $themePreference)';
   }
 }
 
 /// @nodoc
-abstract mixin class $SettingsUiStateCopyWith<$Res> {
-  factory $SettingsUiStateCopyWith(
-          SettingsUiState value, $Res Function(SettingsUiState) _then) =
-      _$SettingsUiStateCopyWithImpl;
+abstract mixin class $SettingsCopyWith<$Res> {
+  factory $SettingsCopyWith(Settings value, $Res Function(Settings) _then) =
+      _$SettingsCopyWithImpl;
   @useResult
   $Res call(
-      {bool isLoading,
-      String? error,
+      {CalendarFormat calendarFormat,
       String? language,
-      CalendarFormat? calendarFormat,
-      String? activeConfigName,
+      String? selectedDutyGroup,
       String? myDutyGroup,
+      String? activeConfigName,
       ThemePreference? themePreference});
 }
 
 /// @nodoc
-class _$SettingsUiStateCopyWithImpl<$Res>
-    implements $SettingsUiStateCopyWith<$Res> {
-  _$SettingsUiStateCopyWithImpl(this._self, this._then);
+class _$SettingsCopyWithImpl<$Res> implements $SettingsCopyWith<$Res> {
+  _$SettingsCopyWithImpl(this._self, this._then);
 
-  final SettingsUiState _self;
-  final $Res Function(SettingsUiState) _then;
+  final Settings _self;
+  final $Res Function(Settings) _then;
 
-  /// Create a copy of SettingsUiState
+  /// Create a copy of Settings
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isLoading = null,
-    Object? error = freezed,
+    Object? calendarFormat = null,
     Object? language = freezed,
-    Object? calendarFormat = freezed,
-    Object? activeConfigName = freezed,
+    Object? selectedDutyGroup = freezed,
     Object? myDutyGroup = freezed,
+    Object? activeConfigName = freezed,
     Object? themePreference = freezed,
   }) {
     return _then(_self.copyWith(
-      isLoading: null == isLoading
-          ? _self.isLoading
-          : isLoading // ignore: cast_nullable_to_non_nullable
-              as bool,
-      error: freezed == error
-          ? _self.error
-          : error // ignore: cast_nullable_to_non_nullable
-              as String?,
+      calendarFormat: null == calendarFormat
+          ? _self.calendarFormat
+          : calendarFormat // ignore: cast_nullable_to_non_nullable
+              as CalendarFormat,
       language: freezed == language
           ? _self.language
           : language // ignore: cast_nullable_to_non_nullable
               as String?,
-      calendarFormat: freezed == calendarFormat
-          ? _self.calendarFormat
-          : calendarFormat // ignore: cast_nullable_to_non_nullable
-              as CalendarFormat?,
-      activeConfigName: freezed == activeConfigName
-          ? _self.activeConfigName
-          : activeConfigName // ignore: cast_nullable_to_non_nullable
+      selectedDutyGroup: freezed == selectedDutyGroup
+          ? _self.selectedDutyGroup
+          : selectedDutyGroup // ignore: cast_nullable_to_non_nullable
               as String?,
       myDutyGroup: freezed == myDutyGroup
           ? _self.myDutyGroup
           : myDutyGroup // ignore: cast_nullable_to_non_nullable
+              as String?,
+      activeConfigName: freezed == activeConfigName
+          ? _self.activeConfigName
+          : activeConfigName // ignore: cast_nullable_to_non_nullable
               as String?,
       themePreference: freezed == themePreference
           ? _self.themePreference
@@ -130,8 +119,8 @@ class _$SettingsUiStateCopyWithImpl<$Res>
   }
 }
 
-/// Adds pattern-matching-related methods to [SettingsUiState].
-extension SettingsUiStatePatterns on SettingsUiState {
+/// Adds pattern-matching-related methods to [Settings].
+extension SettingsPatterns on Settings {
   /// A variant of `map` that fallback to returning `orElse`.
   ///
   /// It is equivalent to doing:
@@ -146,12 +135,12 @@ extension SettingsUiStatePatterns on SettingsUiState {
 
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>(
-    TResult Function(_SettingsUiState value)? $default, {
+    TResult Function(_Settings value)? $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
-      case _SettingsUiState() when $default != null:
+      case _Settings() when $default != null:
         return $default(_that);
       case _:
         return orElse();
@@ -173,11 +162,11 @@ extension SettingsUiStatePatterns on SettingsUiState {
 
   @optionalTypeArgs
   TResult map<TResult extends Object?>(
-    TResult Function(_SettingsUiState value) $default,
+    TResult Function(_Settings value) $default,
   ) {
     final _that = this;
     switch (_that) {
-      case _SettingsUiState():
+      case _Settings():
         return $default(_that);
       case _:
         throw StateError('Unexpected subclass');
@@ -198,11 +187,11 @@ extension SettingsUiStatePatterns on SettingsUiState {
 
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_SettingsUiState value)? $default,
+    TResult? Function(_Settings value)? $default,
   ) {
     final _that = this;
     switch (_that) {
-      case _SettingsUiState() when $default != null:
+      case _Settings() when $default != null:
         return $default(_that);
       case _:
         return null;
@@ -224,26 +213,24 @@ extension SettingsUiStatePatterns on SettingsUiState {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
     TResult Function(
-            bool isLoading,
-            String? error,
+            CalendarFormat calendarFormat,
             String? language,
-            CalendarFormat? calendarFormat,
-            String? activeConfigName,
+            String? selectedDutyGroup,
             String? myDutyGroup,
+            String? activeConfigName,
             ThemePreference? themePreference)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
-      case _SettingsUiState() when $default != null:
+      case _Settings() when $default != null:
         return $default(
-            _that.isLoading,
-            _that.error,
-            _that.language,
             _that.calendarFormat,
-            _that.activeConfigName,
+            _that.language,
+            _that.selectedDutyGroup,
             _that.myDutyGroup,
+            _that.activeConfigName,
             _that.themePreference);
       case _:
         return orElse();
@@ -266,25 +253,23 @@ extension SettingsUiStatePatterns on SettingsUiState {
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
     TResult Function(
-            bool isLoading,
-            String? error,
+            CalendarFormat calendarFormat,
             String? language,
-            CalendarFormat? calendarFormat,
-            String? activeConfigName,
+            String? selectedDutyGroup,
             String? myDutyGroup,
+            String? activeConfigName,
             ThemePreference? themePreference)
         $default,
   ) {
     final _that = this;
     switch (_that) {
-      case _SettingsUiState():
+      case _Settings():
         return $default(
-            _that.isLoading,
-            _that.error,
-            _that.language,
             _that.calendarFormat,
-            _that.activeConfigName,
+            _that.language,
+            _that.selectedDutyGroup,
             _that.myDutyGroup,
+            _that.activeConfigName,
             _that.themePreference);
       case _:
         throw StateError('Unexpected subclass');
@@ -306,25 +291,23 @@ extension SettingsUiStatePatterns on SettingsUiState {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
     TResult? Function(
-            bool isLoading,
-            String? error,
+            CalendarFormat calendarFormat,
             String? language,
-            CalendarFormat? calendarFormat,
-            String? activeConfigName,
+            String? selectedDutyGroup,
             String? myDutyGroup,
+            String? activeConfigName,
             ThemePreference? themePreference)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
-      case _SettingsUiState() when $default != null:
+      case _Settings() when $default != null:
         return $default(
-            _that.isLoading,
-            _that.error,
-            _that.language,
             _that.calendarFormat,
-            _that.activeConfigName,
+            _that.language,
+            _that.selectedDutyGroup,
             _that.myDutyGroup,
+            _that.activeConfigName,
             _that.themePreference);
       case _:
         return null;
@@ -334,133 +317,121 @@ extension SettingsUiStatePatterns on SettingsUiState {
 
 /// @nodoc
 
-class _SettingsUiState extends SettingsUiState {
-  const _SettingsUiState(
-      {required this.isLoading,
-      this.error,
+class _Settings extends Settings {
+  const _Settings(
+      {required this.calendarFormat,
       this.language,
-      this.calendarFormat,
-      this.activeConfigName,
+      this.selectedDutyGroup,
       this.myDutyGroup,
+      this.activeConfigName,
       this.themePreference})
       : super._();
 
   @override
-  final bool isLoading;
-  @override
-  final String? error;
+  final CalendarFormat calendarFormat;
   @override
   final String? language;
   @override
-  final CalendarFormat? calendarFormat;
-  @override
-  final String? activeConfigName;
+  final String? selectedDutyGroup;
   @override
   final String? myDutyGroup;
   @override
+  final String? activeConfigName;
+  @override
   final ThemePreference? themePreference;
 
-  /// Create a copy of SettingsUiState
+  /// Create a copy of Settings
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
-  _$SettingsUiStateCopyWith<_SettingsUiState> get copyWith =>
-      __$SettingsUiStateCopyWithImpl<_SettingsUiState>(this, _$identity);
+  _$SettingsCopyWith<_Settings> get copyWith =>
+      __$SettingsCopyWithImpl<_Settings>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _SettingsUiState &&
-            (identical(other.isLoading, isLoading) ||
-                other.isLoading == isLoading) &&
-            (identical(other.error, error) || other.error == error) &&
-            (identical(other.language, language) ||
-                other.language == language) &&
+            other is _Settings &&
             (identical(other.calendarFormat, calendarFormat) ||
                 other.calendarFormat == calendarFormat) &&
-            (identical(other.activeConfigName, activeConfigName) ||
-                other.activeConfigName == activeConfigName) &&
+            (identical(other.language, language) ||
+                other.language == language) &&
+            (identical(other.selectedDutyGroup, selectedDutyGroup) ||
+                other.selectedDutyGroup == selectedDutyGroup) &&
             (identical(other.myDutyGroup, myDutyGroup) ||
                 other.myDutyGroup == myDutyGroup) &&
+            (identical(other.activeConfigName, activeConfigName) ||
+                other.activeConfigName == activeConfigName) &&
             (identical(other.themePreference, themePreference) ||
                 other.themePreference == themePreference));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, isLoading, error, language,
-      calendarFormat, activeConfigName, myDutyGroup, themePreference);
+  int get hashCode => Object.hash(runtimeType, calendarFormat, language,
+      selectedDutyGroup, myDutyGroup, activeConfigName, themePreference);
 
   @override
   String toString() {
-    return 'SettingsUiState(isLoading: $isLoading, error: $error, language: $language, calendarFormat: $calendarFormat, activeConfigName: $activeConfigName, myDutyGroup: $myDutyGroup, themePreference: $themePreference)';
+    return 'Settings(calendarFormat: $calendarFormat, language: $language, selectedDutyGroup: $selectedDutyGroup, myDutyGroup: $myDutyGroup, activeConfigName: $activeConfigName, themePreference: $themePreference)';
   }
 }
 
 /// @nodoc
-abstract mixin class _$SettingsUiStateCopyWith<$Res>
-    implements $SettingsUiStateCopyWith<$Res> {
-  factory _$SettingsUiStateCopyWith(
-          _SettingsUiState value, $Res Function(_SettingsUiState) _then) =
-      __$SettingsUiStateCopyWithImpl;
+abstract mixin class _$SettingsCopyWith<$Res>
+    implements $SettingsCopyWith<$Res> {
+  factory _$SettingsCopyWith(_Settings value, $Res Function(_Settings) _then) =
+      __$SettingsCopyWithImpl;
   @override
   @useResult
   $Res call(
-      {bool isLoading,
-      String? error,
+      {CalendarFormat calendarFormat,
       String? language,
-      CalendarFormat? calendarFormat,
-      String? activeConfigName,
+      String? selectedDutyGroup,
       String? myDutyGroup,
+      String? activeConfigName,
       ThemePreference? themePreference});
 }
 
 /// @nodoc
-class __$SettingsUiStateCopyWithImpl<$Res>
-    implements _$SettingsUiStateCopyWith<$Res> {
-  __$SettingsUiStateCopyWithImpl(this._self, this._then);
+class __$SettingsCopyWithImpl<$Res> implements _$SettingsCopyWith<$Res> {
+  __$SettingsCopyWithImpl(this._self, this._then);
 
-  final _SettingsUiState _self;
-  final $Res Function(_SettingsUiState) _then;
+  final _Settings _self;
+  final $Res Function(_Settings) _then;
 
-  /// Create a copy of SettingsUiState
+  /// Create a copy of Settings
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $Res call({
-    Object? isLoading = null,
-    Object? error = freezed,
+    Object? calendarFormat = null,
     Object? language = freezed,
-    Object? calendarFormat = freezed,
-    Object? activeConfigName = freezed,
+    Object? selectedDutyGroup = freezed,
     Object? myDutyGroup = freezed,
+    Object? activeConfigName = freezed,
     Object? themePreference = freezed,
   }) {
-    return _then(_SettingsUiState(
-      isLoading: null == isLoading
-          ? _self.isLoading
-          : isLoading // ignore: cast_nullable_to_non_nullable
-              as bool,
-      error: freezed == error
-          ? _self.error
-          : error // ignore: cast_nullable_to_non_nullable
-              as String?,
+    return _then(_Settings(
+      calendarFormat: null == calendarFormat
+          ? _self.calendarFormat
+          : calendarFormat // ignore: cast_nullable_to_non_nullable
+              as CalendarFormat,
       language: freezed == language
           ? _self.language
           : language // ignore: cast_nullable_to_non_nullable
               as String?,
-      calendarFormat: freezed == calendarFormat
-          ? _self.calendarFormat
-          : calendarFormat // ignore: cast_nullable_to_non_nullable
-              as CalendarFormat?,
-      activeConfigName: freezed == activeConfigName
-          ? _self.activeConfigName
-          : activeConfigName // ignore: cast_nullable_to_non_nullable
+      selectedDutyGroup: freezed == selectedDutyGroup
+          ? _self.selectedDutyGroup
+          : selectedDutyGroup // ignore: cast_nullable_to_non_nullable
               as String?,
       myDutyGroup: freezed == myDutyGroup
           ? _self.myDutyGroup
           : myDutyGroup // ignore: cast_nullable_to_non_nullable
+              as String?,
+      activeConfigName: freezed == activeConfigName
+          ? _self.activeConfigName
+          : activeConfigName // ignore: cast_nullable_to_non_nullable
               as String?,
       themePreference: freezed == themePreference
           ? _self.themePreference

--- a/lib/presentation/app.dart
+++ b/lib/presentation/app.dart
@@ -27,16 +27,18 @@ class _MyAppState extends ConsumerState<MyApp> {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = ref.watch(appThemeProvider);
-    final ThemeMode mode = ref.watch(themeModeProvider);
+    final AsyncValue<ThemeMode> modeAsync = ref.watch(themeModeProvider);
     final AsyncValue<Locale> localeAsync = ref.watch(currentLocaleProvider);
-    return localeAsync.when(
-      loading: () => _buildMaterialApp(
-          theme: theme, mode: mode, locale: const Locale('de')),
-      error: (e, st) => _buildMaterialApp(
-          theme: theme, mode: mode, locale: const Locale('de')),
-      data: (locale) =>
-          _buildMaterialApp(theme: theme, mode: mode, locale: locale),
+    // Combine async values with fallbacks
+    final ThemeMode mode = modeAsync.maybeWhen(
+      data: (m) => m,
+      orElse: () => ThemeMode.system,
     );
+    final Locale locale = localeAsync.maybeWhen(
+      data: (l) => l,
+      orElse: () => const Locale('de'),
+    );
+    return _buildMaterialApp(theme: theme, mode: mode, locale: locale);
   }
 
   Widget _buildMaterialApp(

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -20,6 +20,9 @@ import 'package:dienstplan/presentation/widgets/screens/settings/dialogs/general
 import 'package:dienstplan/presentation/widgets/screens/settings/dialogs/general/language_dialog.dart';
 import 'package:dienstplan/presentation/widgets/screens/settings/dialogs/general/my_duty_group_dialog.dart';
 import 'package:dienstplan/presentation/widgets/screens/settings/dialogs/general/reset_dialog.dart';
+import 'package:dienstplan/presentation/widgets/screens/settings/dialogs/general/theme_mode_dialog.dart';
+import 'package:dienstplan/presentation/state/settings/settings_notifier.dart';
+import 'package:dienstplan/domain/entities/settings.dart' show ThemePreference;
 import 'package:dienstplan/core/utils/app_info.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 // ignore: unused_import
@@ -144,6 +147,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     AppLocalizations l10n,
   ) {
     final languageService = ref.watch(languageServiceProvider).value;
+    final themePref =
+        ref.watch(settingsNotifierProvider).valueOrNull?.themePreference;
 
     return SettingsSection(
       title: l10n.app,
@@ -158,6 +163,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           onTap: () => LanguageDialog.show(context),
         ),
         NavigationCard(
+          icon: Icons.color_lens_outlined,
+          title: l10n.themeMode,
+          subtitle: _themeSubtitle(l10n, themePref),
+          trailing: _buildThemeIndicator(themePref),
+          onTap: () => ThemeModeDialog.show(context, ref),
+        ),
+        NavigationCard(
           icon: Icons.delete_forever_outlined,
           title: l10n.resetData,
           onTap: () => ResetDialog.show(context),
@@ -165,6 +177,30 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
       ],
     );
+  }
+
+  String _themeSubtitle(AppLocalizations l10n, ThemePreference? pref) {
+    switch (pref) {
+      case ThemePreference.light:
+        return l10n.themeModeLight;
+      case ThemePreference.dark:
+        return l10n.themeModeDark;
+      case ThemePreference.system:
+      case null:
+        return l10n.themeModeSystem;
+    }
+  }
+
+  Widget _buildThemeIndicator(ThemePreference? pref) {
+    switch (pref) {
+      case ThemePreference.light:
+        return const Icon(Icons.wb_sunny_outlined, color: Colors.amber);
+      case ThemePreference.dark:
+        return const Icon(Icons.nightlight_round, color: Colors.indigo);
+      case ThemePreference.system:
+      case null:
+        return const Icon(Icons.brightness_auto, color: Colors.grey);
+    }
   }
 
   Widget _buildPrivacySection(

--- a/lib/presentation/state/settings/settings_notifier.dart
+++ b/lib/presentation/state/settings/settings_notifier.dart
@@ -35,6 +35,7 @@ class SettingsNotifier extends _$SettingsNotifier {
         calendarFormat: settings?.calendarFormat,
         activeConfigName: settings?.activeConfigName,
         myDutyGroup: settings?.myDutyGroup,
+        themePreference: settings?.themePreference,
       );
     } catch (e) {
       return current.copyWith(
@@ -48,6 +49,15 @@ class SettingsNotifier extends _$SettingsNotifier {
     final existing = await _getSettingsUseCase!.execute();
     if (existing != null) {
       await _saveSettings(existing.copyWith(language: language));
+    }
+  }
+
+  Future<void> setThemePreference(ThemePreference preference) async {
+    final current = state.valueOrNull ?? SettingsUiState.initial();
+    state = AsyncData(current.copyWith(themePreference: preference));
+    final existing = await _getSettingsUseCase!.execute();
+    if (existing != null) {
+      await _saveSettings(existing.copyWith(themePreference: preference));
     }
   }
 

--- a/lib/presentation/state/settings/settings_notifier.g.dart
+++ b/lib/presentation/state/settings/settings_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'settings_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$settingsNotifierHash() => r'3a7ce5919fcd606bb60d7331c9f9393a3eedcfdd';
+String _$settingsNotifierHash() => r'b64be9e031423a972cc278c1bd5e06daf3252a76';
 
 /// See also [SettingsNotifier].
 @ProviderFor(SettingsNotifier)

--- a/lib/presentation/state/settings/settings_ui_state.dart
+++ b/lib/presentation/state/settings/settings_ui_state.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:table_calendar/table_calendar.dart';
+import 'package:dienstplan/domain/entities/settings.dart' show ThemePreference;
 
 part 'settings_ui_state.freezed.dart';
 
@@ -12,6 +13,7 @@ abstract class SettingsUiState with _$SettingsUiState {
     CalendarFormat? calendarFormat,
     String? activeConfigName,
     String? myDutyGroup,
+    ThemePreference? themePreference,
   }) = _SettingsUiState;
 
   const SettingsUiState._();

--- a/lib/presentation/widgets/common/cards/navigation_card.dart
+++ b/lib/presentation/widgets/common/cards/navigation_card.dart
@@ -7,6 +7,7 @@ class NavigationCard extends StatelessWidget {
   final String? subtitle;
   final VoidCallback? onTap;
   final Color iconColor;
+  final Widget? trailing;
 
   const NavigationCard({
     super.key,
@@ -15,6 +16,7 @@ class NavigationCard extends StatelessWidget {
     this.subtitle,
     this.onTap,
     this.iconColor = AppColors.primary,
+    this.trailing,
   });
 
   @override
@@ -47,6 +49,7 @@ class NavigationCard extends StatelessWidget {
                 style: const TextStyle(fontSize: 15, color: Colors.black87),
               )
             : null,
+        trailing: trailing,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
         ),

--- a/lib/presentation/widgets/screens/settings/dialogs/general/theme_mode_dialog.dart
+++ b/lib/presentation/widgets/screens/settings/dialogs/general/theme_mode_dialog.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dienstplan/core/l10n/app_localizations.dart';
+import 'package:dienstplan/presentation/state/settings/settings_notifier.dart';
+import 'package:dienstplan/domain/entities/settings.dart';
+
+class ThemeModeDialog {
+  static Future<void> show(BuildContext context, WidgetRef ref) async {
+    final l10n = AppLocalizations.of(context);
+    final state = ref.read(settingsNotifierProvider).valueOrNull;
+    final ThemePreference current =
+        state?.themePreference ?? ThemePreference.light;
+
+    ThemePreference selected = current;
+
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: Text(l10n.themeMode),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RadioListTile<ThemePreference>(
+                title: Text(l10n.themeModeLight),
+                value: ThemePreference.light,
+                groupValue: selected,
+                onChanged: (val) {
+                  if (val == null) return;
+                  selected = val;
+                  Navigator.of(ctx).pop();
+                  _applySelection(context, ref, selected, l10n);
+                },
+              ),
+              RadioListTile<ThemePreference>(
+                title: Text(l10n.themeModeDark),
+                value: ThemePreference.dark,
+                groupValue: selected,
+                onChanged: (val) {
+                  if (val == null) return;
+                  selected = val;
+                  Navigator.of(ctx).pop();
+                  _applySelection(context, ref, selected, l10n);
+                },
+              ),
+              RadioListTile<ThemePreference>(
+                title: Text(l10n.themeModeSystem),
+                value: ThemePreference.system,
+                groupValue: selected,
+                onChanged: (val) {
+                  if (val == null) return;
+                  selected = val;
+                  Navigator.of(ctx).pop();
+                  _applySelection(context, ref, selected, l10n);
+                },
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text(l10n.cancel),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  static void _applySelection(BuildContext context, WidgetRef ref,
+      ThemePreference preference, AppLocalizations l10n) {
+    ref.read(settingsNotifierProvider.notifier).setThemePreference(preference);
+    if (preference != ThemePreference.light) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.darkModeNotAvailableYet)),
+      );
+    }
+  }
+}


### PR DESCRIPTION
Update Technical Features to reflect Riverpod-based DI and state management Remove GetIt references; document providers as DI mechanism Update Key Dependencies to match pubspec (flutter_riverpod, riverpod_annotation, freezed_annotation) and versions Revise Architecture Patterns to use Riverpod for state and DI Verify no remaining GetIt/Provider/ChangeNotifier mentions in docs No code changes; docs only (README.md).

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Context
<!-- Add any other context about the pull request here --> 