### PR TITLE
fix: align cold start with visible calendar range

### DIFF
--- a/lib/core/constants/schedule_constants.dart
+++ b/lib/core/constants/schedule_constants.dart
@@ -10,9 +10,6 @@ const int kInitialEnsureMonthsRadius = 1;
 // Number of months to keep in memory to prevent accumulation (past months)
 const int kMonthsToKeepInMemory = 4;
 
-// Expected number of schedules per day (used for coverage heuristic)
-const int kExpectedSchedulesPerDay = 5;
-
 // Fraction of expected schedules that indicates sufficient coverage
 const double kCoverageThreshold = 0.8;
 

--- a/lib/core/di/riverpod_providers.dart
+++ b/lib/core/di/riverpod_providers.dart
@@ -408,10 +408,13 @@ Future<EnsureMonthSchedulesUseCase> ensureMonthSchedulesUseCase(Ref ref) async {
   final ScheduleRepository repo = await ref.watch(
     scheduleRepositoryProvider.future,
   );
+  final ConfigRepository configRepo = await ref.watch(
+    configRepositoryProvider.future,
+  );
   final GenerateSchedulesUseCase gen = await ref.watch(
     generateSchedulesUseCaseProvider.future,
   );
-  return EnsureMonthSchedulesUseCase(repo, gen);
+  return EnsureMonthSchedulesUseCase(repo, configRepo, gen);
 }
 
 final generateCalendarExportUseCaseProvider =

--- a/lib/core/utils/calendar_date_math.dart
+++ b/lib/core/utils/calendar_date_math.dart
@@ -1,0 +1,17 @@
+/// Pure calendar arithmetic using UTC date components only. Not shortened by
+/// local DST when spanning start/end that are local midnights.
+DateTime utcCalendarDateOnly(DateTime d) =>
+    DateTime.utc(d.year, d.month, d.day);
+
+/// Difference in whole calendar days from [start] to [end] (inclusive end as
+/// same count as looping `i` from `0` through this value with
+/// `utcCalendarDateOnly(start).add(Duration(days: i))`).
+int utcCalendarDaySpan(DateTime start, DateTime end) {
+  final DateTime s = utcCalendarDateOnly(start);
+  final DateTime e = utcCalendarDateOnly(end);
+  return e.difference(s).inDays;
+}
+
+/// Inclusive calendar day count (e.g. Mar 1–Mar 31 → 31).
+int utcCalendarInclusiveDayCount(DateTime start, DateTime end) =>
+    utcCalendarDaySpan(start, end) + 1;

--- a/lib/core/utils/schedule_key_helper.dart
+++ b/lib/core/utils/schedule_key_helper.dart
@@ -17,11 +17,13 @@ class ScheduleKeyParts {
 class ScheduleKeyHelper {
   static const String _separator = '_';
 
+  /// Calendar y-m-d in [date]'s timezone (local or UTC). Do not use [toUtc] here:
+  /// local midnights for range ends (e.g. last day of month) must not shift to the
+  /// previous UTC day, or SQL `date_ymd` bounds drop the last calendar day (DST).
   static String formatDateYmd(DateTime date) {
-    final DateTime utc = date.toUtc();
-    final String y = utc.year.toString().padLeft(4, '0');
-    final String m = utc.month.toString().padLeft(2, '0');
-    final String d = utc.day.toString().padLeft(2, '0');
+    final String y = date.year.toString().padLeft(4, '0');
+    final String m = date.month.toString().padLeft(2, '0');
+    final String d = date.day.toString().padLeft(2, '0');
     return '$y-$m-$d';
   }
 

--- a/lib/data/daos/maintenance_dao.dart
+++ b/lib/data/daos/maintenance_dao.dart
@@ -1,3 +1,4 @@
+import 'package:dienstplan/core/utils/schedule_key_helper.dart';
 import 'package:dienstplan/data/services/database_service.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:sqflite/sqflite.dart';
@@ -28,7 +29,7 @@ class MaintenanceDao {
       final db = await _databaseService.database;
       final cutoffDate = DateTime.now().subtract(Duration(days: daysToKeep));
       // Use date_ymd for better index utilization
-      final cutoffYmd = _formatDateYmd(cutoffDate);
+      final cutoffYmd = ScheduleKeyHelper.formatDateYmd(cutoffDate);
       final deleted = await db.delete(
         'schedules',
         where: 'date_ymd < ?',
@@ -39,14 +40,6 @@ class MaintenanceDao {
       AppLogger.e('MaintenanceDao: Error cleaning up old data', e, stackTrace);
       rethrow;
     }
-  }
-
-  String _formatDateYmd(DateTime date) {
-    final DateTime utc = date.toUtc();
-    final String y = utc.year.toString().padLeft(4, '0');
-    final String m = utc.month.toString().padLeft(2, '0');
-    final String d = utc.day.toString().padLeft(2, '0');
-    return '$y-$m-$d';
   }
 
   Future<bool> hasData() async {

--- a/lib/data/services/schedule_config_service.dart
+++ b/lib/data/services/schedule_config_service.dart
@@ -9,6 +9,7 @@ import 'package:dienstplan/data/models/schedule.dart';
 import 'package:dienstplan/data/models/duty_schedule_config.dart';
 import 'package:dienstplan/data/daos/schedule_configs_dao.dart';
 import 'package:dienstplan/data/daos/schedules_admin_dao.dart';
+import 'package:dienstplan/core/utils/calendar_date_math.dart';
 import 'package:dienstplan/core/utils/logger.dart';
 import 'package:dienstplan/core/constants/prefs_keys.dart';
 import 'package:dienstplan/data/services/notification_service.dart';
@@ -299,9 +300,11 @@ class ScheduleConfigService extends ChangeNotifier {
     final effectiveEndDate =
         endDate ?? config.startDate.add(const Duration(days: 27375));
 
-    final daysToGenerate = effectiveEndDate
-        .difference(effectiveStartDate)
-        .inDays;
+    final DateTime rangeStart = utcCalendarDateOnly(effectiveStartDate);
+    final int daysToGenerate = utcCalendarDaySpan(
+      effectiveStartDate,
+      effectiveEndDate,
+    );
     AppLogger.i(
       'Generating schedules for ${daysToGenerate + 1} days from ${effectiveStartDate.toIso8601String()} to ${effectiveEndDate.toIso8601String()}',
     );
@@ -336,8 +339,7 @@ class ScheduleConfigService extends ChangeNotifier {
       final batchSchedules = <Schedule>[];
 
       for (var i = batchStart; i <= batchEnd; i++) {
-        final date = effectiveStartDate.add(Duration(days: i));
-        final normalizedDate = DateTime.utc(date.year, date.month, date.day);
+        final DateTime normalizedDate = rangeStart.add(Duration(days: i));
 
         final deltaDays = normalizedDate.difference(normalizedStartDate).inDays;
 

--- a/lib/domain/entities/duty_schedule_config.dart
+++ b/lib/domain/entities/duty_schedule_config.dart
@@ -21,4 +21,7 @@ abstract class DutyScheduleConfig with _$DutyScheduleConfig {
 
   String get name => meta.name;
   DateTime get startDate => meta.startDate;
+
+  /// Generation emits at most one schedule row per duty group per calendar day.
+  int get expectedSchedulesPerCalendarDay => dutyGroups.length;
 }

--- a/lib/domain/policies/date_range_policy.dart
+++ b/lib/domain/policies/date_range_policy.dart
@@ -23,15 +23,9 @@ class PlusMinusMonthsPolicy implements DateRangePolicy {
 
   @override
   DateRange computeInitialRange(DateTime anchor) {
-    // Load only current month + 1 month ahead for initial load
-    // This allows dynamic loading to be tested when navigating beyond this range
-    final DateTime start = DateTime(anchor.year, anchor.month, 1);
-    final DateTime end = DateTime(
-      anchor.year,
-      anchor.month + 2, // Current month + 1 month ahead
-      0,
-    );
-    return DateRange(start: start, end: end);
+    // Must match visible month grid (leading/trailing days): same window as
+    // computeFocusedRange so cold start loads data for neighbor months.
+    return computeFocusedRange(anchor);
   }
 
   @override

--- a/lib/domain/use_cases/ensure_month_schedules_use_case.dart
+++ b/lib/domain/use_cases/ensure_month_schedules_use_case.dart
@@ -1,15 +1,19 @@
+import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
 import 'package:dienstplan/domain/entities/schedule.dart';
-import 'package:dienstplan/domain/use_cases/generate_schedules_use_case.dart';
-import 'package:dienstplan/domain/repositories/schedule_repository.dart';
-import 'package:dienstplan/core/constants/schedule_constants.dart';
+import 'package:dienstplan/domain/failures/failure.dart';
 import 'package:dienstplan/domain/failures/result.dart';
+import 'package:dienstplan/domain/repositories/config_repository.dart';
+import 'package:dienstplan/domain/repositories/schedule_repository.dart';
+import 'package:dienstplan/domain/use_cases/generate_schedules_use_case.dart';
 
 class EnsureMonthSchedulesUseCase {
   final ScheduleRepository _scheduleRepository;
+  final ConfigRepository _configRepository;
   final GenerateSchedulesUseCase _generateSchedulesUseCase;
 
   EnsureMonthSchedulesUseCase(
     this._scheduleRepository,
+    this._configRepository,
     this._generateSchedulesUseCase,
   );
 
@@ -23,16 +27,36 @@ class EnsureMonthSchedulesUseCase {
       0,
     );
     final int daysInMonth = monthEnd.day;
-    const int expectedPerDay = kExpectedSchedulesPerDay;
-    const double coverageThreshold = kCoverageThreshold;
-    final int expectedTotal = daysInMonth * expectedPerDay;
     final Result<int> countResult = await _scheduleRepository
         .countSchedulesForMonth(month: monthStart, configName: configName);
     if (countResult.isFailure) {
       return Result.createFailure<List<Schedule>>(countResult.failure);
     }
     final int count = countResult.value;
-    if (count >= (expectedTotal * coverageThreshold).floor()) {
+    final Result<List<DutyScheduleConfig>> configsResult =
+        await _configRepository.getConfigs();
+    if (configsResult.isFailure) {
+      return Result.createFailure<List<Schedule>>(configsResult.failure);
+    }
+    DutyScheduleConfig? matched;
+    for (final DutyScheduleConfig c in configsResult.value) {
+      if (c.name == configName) {
+        matched = c;
+        break;
+      }
+    }
+    if (matched == null) {
+      return Result.createFailure<List<Schedule>>(
+        ValidationFailure(
+          technicalMessage: 'Configuration not found: $configName',
+        ),
+      );
+    }
+    final int schedulesPerDay = matched.expectedSchedulesPerCalendarDay;
+    final int expectedTotal = daysInMonth * schedulesPerDay;
+    // Do not use a coverage threshold here: e.g. 30/31 days filled (150/155)
+    // passes 80% but still needs gap fill from GenerateSchedulesUseCase.
+    if (schedulesPerDay > 0 && count >= expectedTotal) {
       final Result<List<Schedule>> rangeResult = await _scheduleRepository
           .getSchedulesForDateRange(
             start: monthStart,

--- a/lib/domain/use_cases/generate_schedules_use_case.dart
+++ b/lib/domain/use_cases/generate_schedules_use_case.dart
@@ -1,3 +1,4 @@
+import 'package:dienstplan/core/utils/calendar_date_math.dart';
 import 'package:dienstplan/domain/entities/schedule.dart';
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
 import 'package:dienstplan/domain/repositories/schedule_repository.dart';
@@ -67,10 +68,14 @@ class GenerateSchedulesUseCase {
         return Result.createFailure<List<Schedule>>(existingResult.failure);
       }
       final List<Schedule> existingSchedules = existingResult.value;
-      const int expectedSchedulesPerDay = kExpectedSchedulesPerDay;
-      final int daysDifference = endDate.difference(startDate).inDays;
+      final int expectedSchedulesPerDay =
+          config.expectedSchedulesPerCalendarDay;
+      final int inclusiveCalendarDays = utcCalendarInclusiveDayCount(
+        startDate,
+        endDate,
+      );
       final int expectedTotalSchedules =
-          daysDifference * expectedSchedulesPerDay;
+          inclusiveCalendarDays * expectedSchedulesPerDay;
       const double coverageThreshold = kCoverageThreshold;
       if (existingSchedules.length >=
           expectedTotalSchedules * coverageThreshold) {

--- a/lib/presentation/state/schedule/schedule_notifier.dart
+++ b/lib/presentation/state/schedule/schedule_notifier.dart
@@ -369,7 +369,8 @@ class ScheduleNotifier extends _$ScheduleNotifier {
           }
         }
 
-        // Ensure focused, previous and next months exist (generate only when empty or without valid items for active config)
+        // Ensure previous, focused, and next months exist (must match
+        // computeFocusedRange visible trailing/leading days).
         Future<void> ensureMonthGenerated(DateTime monthStart) async {
           final Result<List<Schedule>> ensuredResult =
               await _ensureMonthSchedulesUseCase!.execute(
@@ -381,9 +382,8 @@ class ScheduleNotifier extends _$ScheduleNotifier {
           }
         }
 
-        // Generate focused month and next N months in parallel using isolate
         await Future.wait(<Future<void>>[
-          for (int i = 0; i <= kMonthsPrefetchRadius; i++)
+          for (int i = -kMonthsPrefetchRadius; i <= kMonthsPrefetchRadius; i++)
             ensureMonthGenerated(DateTime(day.year, day.month + i, 1)),
         ]);
 
@@ -401,7 +401,11 @@ class ScheduleNotifier extends _$ScheduleNotifier {
           }
 
           await Future.wait(<Future<void>>[
-            for (int i = 0; i <= kMonthsPrefetchRadius; i++)
+            for (
+              int i = -kMonthsPrefetchRadius;
+              i <= kMonthsPrefetchRadius;
+              i++
+            )
               ensurePartnerMonthGenerated(DateTime(day.year, day.month + i, 1)),
           ]);
         }
@@ -860,7 +864,7 @@ class ScheduleNotifier extends _$ScheduleNotifier {
       }
 
       await Future.wait(<Future<void>>[
-        for (int i = 0; i <= kMonthsPrefetchRadius; i++)
+        for (int i = -kMonthsPrefetchRadius; i <= kMonthsPrefetchRadius; i++)
           ensurePartnerMonth(DateTime(focused.year, focused.month + i, 1)),
       ]);
 
@@ -919,7 +923,7 @@ class ScheduleNotifier extends _$ScheduleNotifier {
       }
 
       await Future.wait(<Future<void>>[
-        for (int i = 0; i <= kMonthsPrefetchRadius; i++)
+        for (int i = -kMonthsPrefetchRadius; i <= kMonthsPrefetchRadius; i++)
           ensureActiveMonth(DateTime(focused.year, focused.month + i, 1)),
       ]);
 

--- a/lib/presentation/state/schedule_data/schedule_data_notifier.dart
+++ b/lib/presentation/state/schedule_data/schedule_data_notifier.dart
@@ -10,6 +10,7 @@ import 'package:dienstplan/domain/policies/date_range_policy.dart';
 import 'package:dienstplan/domain/services/schedule_merge_service.dart';
 import 'package:dienstplan/domain/value_objects/date_range.dart';
 import 'package:dienstplan/core/di/riverpod_providers.dart';
+import 'package:dienstplan/core/constants/schedule_constants.dart';
 import 'package:dienstplan/domain/failures/failure.dart';
 import 'package:dienstplan/domain/failures/result.dart';
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
@@ -105,6 +106,41 @@ class ScheduleDataNotifier extends _$ScheduleDataNotifier {
 
         if (schedulesResult.isSuccess) {
           schedules = schedulesResult.value;
+          final List<Result<List<Schedule>>> ensureResults =
+              await Future.wait(<Future<Result<List<Schedule>>>>[
+                for (
+                  int i = -kMonthsPrefetchRadius;
+                  i <= kMonthsPrefetchRadius;
+                  i++
+                )
+                  _ensureMonthSchedulesUseCase!.execute(
+                    configName: activeConfigName,
+                    monthStart: DateTime(now.year, now.month + i, 1),
+                  ),
+              ]);
+          final int ensureCount = ensureResults.length;
+          for (int idx = 0; idx < ensureCount; idx++) {
+            final Result<List<Schedule>> ensured = ensureResults[idx];
+            final int monthOffset = -kMonthsPrefetchRadius + idx;
+            final DateTime ensuredMonth = DateTime(
+              now.year,
+              now.month + monthOffset,
+              1,
+            );
+            if (ensured.isSuccess) {
+              schedules = _scheduleMergeService!.upsertByKey(
+                existing: schedules,
+                incoming: ensured.value,
+              );
+            } else {
+              await AppLogger.w(
+                'Failed to ensure schedules during cold start '
+                '(configName=$activeConfigName, year=${ensuredMonth.year}, '
+                'month=${ensuredMonth.month}, failureCode=${ensured.failure.code}, '
+                'reason=${ensured.failure.technicalMessage})',
+              );
+            }
+          }
         } else {
           final message = await _presentFailure(schedulesResult.failure);
           return ScheduleDataUiState(

--- a/lib/shared/utils/schedule_isolate.dart
+++ b/lib/shared/utils/schedule_isolate.dart
@@ -1,4 +1,5 @@
 import 'dart:isolate';
+import 'package:dienstplan/core/utils/calendar_date_math.dart';
 import 'package:dienstplan/domain/entities/schedule.dart';
 import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
 import 'package:dienstplan/domain/services/schedule_merge_service.dart';
@@ -186,7 +187,8 @@ class ScheduleGenerationIsolate {
   ) {
     final schedules = <Schedule>[];
 
-    final daysToGenerate = endDate.difference(startDate).inDays;
+    final DateTime rangeStart = utcCalendarDateOnly(startDate);
+    final int daysToGenerate = utcCalendarDaySpan(startDate, endDate);
 
     // Pre-calculate normalized start date
     final normalizedStartDate = DateTime.utc(
@@ -208,8 +210,7 @@ class ScheduleGenerationIsolate {
     final dutyTypes = config.dutyTypes;
 
     for (var i = 0; i <= daysToGenerate; i++) {
-      final date = startDate.add(Duration(days: i));
-      final normalizedDate = DateTime.utc(date.year, date.month, date.day);
+      final DateTime normalizedDate = rangeStart.add(Duration(days: i));
 
       final deltaDays = normalizedDate.difference(normalizedStartDate).inDays;
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
ScheduleDataNotifier used a narrow initial range and skipped ensure for the previous month, so trailing days (e.g. 31 Mar in April view) stayed empty until navigating to that month.

- Use computeFocusedRange for computeInitialRange (same window as UI).
- After initial load, ensure and merge schedules for [-kMonthsPrefetchRadius, +kMonthsPrefetchRadius].
- Extend ScheduleNotifier month ensure loops to include the previous month for parity with the coordinator.


## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Context
<!-- Add any other context about the pull request here --> 