### PR TITLE
fix: reduce bottom sheet blur overhead

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="io.scelus.dienstplan">
     <!-- Internet permission for initial data download -->
     <uses-permission
@@ -9,7 +10,8 @@
         android:maxSdkVersion="32"/>
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32"/>
+        android:maxSdkVersion="32"
+        tools:replace="android:maxSdkVersion"/>
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/lib/presentation/widgets/common/glass_backdrop_blur_scope.dart
+++ b/lib/presentation/widgets/common/glass_backdrop_blur_scope.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+
+/// Controls whether nested glass controls should apply their own BackdropFilter.
+///
+/// Modal glass surfaces already blur the page behind them. Disabling descendant
+/// blur keeps the same translucent tint/border styling while avoiding multiple
+/// overlapping blur passes during sheet route animations and drag gestures.
+class GlassBackdropBlurScope extends InheritedWidget {
+  final bool enabled;
+
+  const GlassBackdropBlurScope({
+    super.key,
+    required this.enabled,
+    required super.child,
+  });
+
+  static bool enabledOf(BuildContext context) {
+    final GlassBackdropBlurScope? scope = context
+        .dependOnInheritedWidgetOfExactType<GlassBackdropBlurScope>();
+    return scope?.enabled ?? true;
+  }
+
+  @override
+  bool updateShouldNotify(GlassBackdropBlurScope oldWidget) {
+    return enabled != oldWidget.enabled;
+  }
+}

--- a/lib/presentation/widgets/common/glass_bottom_sheet.dart
+++ b/lib/presentation/widgets/common/glass_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:dienstplan/core/constants/glass_tokens.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_backdrop_blur_scope.dart';
 import 'package:dienstplan/presentation/widgets/common/glass_dialog_surface.dart';
 import 'package:dienstplan/presentation/widgets/common/scroll_fade_mask.dart';
 
@@ -54,35 +55,38 @@ class GlassBottomSheet extends StatelessWidget {
             borderRadius: const BorderRadius.all(
               Radius.circular(glassSurfaceRadiusLg + glassSpacingSm / 2),
             ),
-            child: Material(
-              color: Colors.transparent,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  if (showHandleBar) _buildDragHandleBar(isDark: isDark),
-                  if (title != null && title!.isNotEmpty)
-                    _buildTitle(context: context, colorScheme: colorScheme),
-                  if (children.isNotEmpty)
-                    Flexible(
-                      fit: FlexFit.loose,
-                      child: ScrollFadeMask(
-                        // Sticky header above + subtle dissolve of scrolled
-                        // content beneath it.
-                        topFadeFraction: _kSheetTopFadeFraction,
-                        bottomFadeFraction: _kSheetBottomFadeFraction,
-                        child: SingleChildScrollView(
-                          child: children.length == 1
-                              ? children.first
-                              : Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: children,
-                                ),
+            child: GlassBackdropBlurScope(
+              enabled: false,
+              child: Material(
+                color: Colors.transparent,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (showHandleBar) _buildDragHandleBar(isDark: isDark),
+                    if (title != null && title!.isNotEmpty)
+                      _buildTitle(context: context, colorScheme: colorScheme),
+                    if (children.isNotEmpty)
+                      Flexible(
+                        fit: FlexFit.loose,
+                        child: ScrollFadeMask(
+                          // Sticky header above + subtle dissolve of scrolled
+                          // content beneath it.
+                          topFadeFraction: _kSheetTopFadeFraction,
+                          bottomFadeFraction: _kSheetBottomFadeFraction,
+                          child: SingleChildScrollView(
+                            child: children.length == 1
+                                ? children.first
+                                : Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: children,
+                                  ),
+                          ),
                         ),
                       ),
-                    ),
-                  const SizedBox(height: glassSpacingMd),
-                ],
+                    const SizedBox(height: glassSpacingMd),
+                  ],
+                ),
               ),
             ),
           ),
@@ -105,33 +109,36 @@ class GlassBottomSheet extends StatelessWidget {
           borderRadius: const BorderRadius.all(
             Radius.circular(glassSurfaceRadiusLg + glassSpacingSm / 2),
           ),
-          child: Material(
-            color: Colors.transparent,
-            child: Column(
-              children: [
-                if (showHandleBar) _buildDragHandleBar(isDark: isDark),
-                if (title != null && title!.isNotEmpty)
-                  _buildTitle(context: context, colorScheme: colorScheme),
-                if (children.isNotEmpty)
-                  Expanded(
-                    // Only auto-fade single-child sheets (the common case:
-                    // a single ListView/GridView/ScrollView). Multi-child
-                    // sheets (e.g. filter + list) must apply ScrollFadeMask
-                    // themselves on the actual scrollable element to avoid
-                    // fading fixed headers at the top.
-                    child: children.length == 1
-                        ? ScrollFadeMask(
-                            topFadeFraction: _kSheetTopFadeFraction,
-                            bottomFadeFraction: _kSheetBottomFadeFraction,
-                            child: children.first,
-                          )
-                        : Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: children,
-                          ),
-                  ),
-                const SizedBox(height: glassSpacingMd),
-              ],
+          child: GlassBackdropBlurScope(
+            enabled: false,
+            child: Material(
+              color: Colors.transparent,
+              child: Column(
+                children: [
+                  if (showHandleBar) _buildDragHandleBar(isDark: isDark),
+                  if (title != null && title!.isNotEmpty)
+                    _buildTitle(context: context, colorScheme: colorScheme),
+                  if (children.isNotEmpty)
+                    Expanded(
+                      // Only auto-fade single-child sheets (the common case:
+                      // a single ListView/GridView/ScrollView). Multi-child
+                      // sheets (e.g. filter + list) must apply ScrollFadeMask
+                      // themselves on the actual scrollable element to avoid
+                      // fading fixed headers at the top.
+                      child: children.length == 1
+                          ? ScrollFadeMask(
+                              topFadeFraction: _kSheetTopFadeFraction,
+                              bottomFadeFraction: _kSheetBottomFadeFraction,
+                              child: children.first,
+                            )
+                          : Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: children,
+                            ),
+                    ),
+                  const SizedBox(height: glassSpacingMd),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/widgets/common/glass_container.dart
+++ b/lib/presentation/widgets/common/glass_container.dart
@@ -5,6 +5,7 @@ import 'package:dienstplan/core/constants/glass_tokens.dart';
 import 'package:dienstplan/presentation/state/partner/partner_notifier.dart';
 import 'package:dienstplan/presentation/state/partner/partner_ui_state.dart';
 import 'package:dienstplan/presentation/widgets/common/ambient_blob.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_backdrop_blur_scope.dart';
 
 /// Reusable glass-morphism container using [BackdropFilter] with a blurred,
 /// semi-transparent tint derived from the current color scheme.
@@ -45,11 +46,15 @@ class GlassContainer extends StatelessWidget {
         : colorScheme.primary.withValues(
             alpha: borderOpacity * glassSurfaceSubtleBorderPrimaryFactorLight,
           );
+    final bool isBackdropBlurEnabled = GlassBackdropBlurScope.enabledOf(
+      context,
+    );
 
     final Widget content = ClipRRect(
       borderRadius: BorderRadius.circular(borderRadius),
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+        enabled: isBackdropBlurEnabled,
         child: Container(
           padding: padding,
           decoration: BoxDecoration(

--- a/lib/presentation/widgets/common/glass_picker_controls.dart
+++ b/lib/presentation/widgets/common/glass_picker_controls.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:dienstplan/core/constants/glass_picker_tokens.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_backdrop_blur_scope.dart';
 
 class GlassPickerPillTrigger extends StatelessWidget {
   final String label;
@@ -18,6 +19,9 @@ class GlassPickerPillTrigger extends StatelessWidget {
   Widget build(BuildContext context) {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     final Color foreground = Theme.of(context).colorScheme.onSurface;
+    final bool isBackdropBlurEnabled = GlassBackdropBlurScope.enabledOf(
+      context,
+    );
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -30,6 +34,7 @@ class GlassPickerPillTrigger extends StatelessWidget {
               sigmaX: kGlassPickerTriggerBlur,
               sigmaY: kGlassPickerTriggerBlur,
             ),
+            enabled: isBackdropBlurEnabled,
             child: Container(
               padding: const EdgeInsets.fromLTRB(
                 kGlassPickerTriggerPaddingHorizontal,

--- a/test/presentation/glass_bottom_sheet_performance_test.dart
+++ b/test/presentation/glass_bottom_sheet_performance_test.dart
@@ -1,0 +1,38 @@
+import 'package:dienstplan/presentation/widgets/common/glass_bottom_sheet.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_filter_chip.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_picker_controls.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('bottom sheet keeps only the root backdrop blur active', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GlassBottomSheet(
+            shrinkToContent: true,
+            children: <Widget>[
+              GlassFilterChip(label: 'Dienst', isSelected: true, onTap: () {}),
+              GlassPickerPillTrigger(label: 'Juni 2026', onTap: () {}),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Iterable<BackdropFilter> filters = tester.widgetList(
+      find.byType(BackdropFilter),
+    );
+
+    expect(
+      filters.where((BackdropFilter filter) => filter.enabled),
+      hasLength(1),
+    );
+    expect(
+      filters.where((BackdropFilter filter) => !filter.enabled),
+      isNotEmpty,
+    );
+  });
+}


### PR DESCRIPTION
## Description
Reduces BottomSheet animation and drag overhead by keeping the root glass blur on the sheet surface while disabling nested BackdropFilter passes for descendant glass controls. The visual style is preserved through the existing tint, border, and shadow treatment.

Root cause: BottomSheets rendered a full-surface blur and nested controls such as glass chips and picker triggers could add additional active BackdropFilter layers. Those layers move together during modal transitions and drag gestures, increasing GPU compositing work.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Not applicable.

## Additional Context
Validation:
- `flutter analyze` passed with no issues.
- `flutter test` passed with 65 tests.
- `./gradlew test` and `./gradlew build` currently fail in the transitive `:flutter_local_notifications:testDebugUnitTest` task with `IllegalArgumentException at ClassReader.java:200`.
- `./gradlew spotlessApply` is not available in the Android Gradle project (`Task 'spotlessApply' not found`).
