### PR TITLE
fix: improve dark filter chip contrast

### DIFF
--- a/lib/presentation/widgets/common/glass_filter_chip.dart
+++ b/lib/presentation/widgets/common/glass_filter_chip.dart
@@ -33,9 +33,11 @@ class GlassFilterChip extends StatelessWidget {
     final double borderOpacity = isSelected
         ? glassBorderAlphaActive
         : (isDark ? glassBorderAlphaDark : glassBorderAlphaLight);
-    final Color textColor = isSelected
-        ? colorScheme.primary
-        : colorScheme.onSurface;
+    final Color textColor = _resolveFilterChipTextColor(
+      colorScheme: colorScheme,
+      isDark: isDark,
+      isSelected: isSelected,
+    );
     final TextStyle? labelBaseStyle = Theme.of(context).textTheme.labelLarge;
     final TextStyle labelStyle = (labelBaseStyle ?? const TextStyle()).copyWith(
       color: textColor,
@@ -175,6 +177,23 @@ class GlassIconToggleChip extends StatelessWidget {
     }
     return Tooltip(message: tooltip!, child: chip);
   }
+}
+
+Color _resolveFilterChipTextColor({
+  required ColorScheme colorScheme,
+  required bool isDark,
+  required bool isSelected,
+}) {
+  if (!isSelected) {
+    return colorScheme.onSurface;
+  }
+  if (!isDark) {
+    return colorScheme.primary;
+  }
+  return _resolveReadableForeground(
+    background: colorScheme.primary,
+    preferred: colorScheme.onSurface,
+  );
 }
 
 Color _resolveReadableForeground({

--- a/test/presentation/glass_filter_chip_test.dart
+++ b/test/presentation/glass_filter_chip_test.dart
@@ -1,0 +1,48 @@
+import 'package:dienstplan/core/constants/app_colors.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_filter_chip.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('selected filter chip keeps readable text in dark mode', (
+    WidgetTester tester,
+  ) async {
+    final ColorScheme colorScheme = ColorScheme.fromSeed(
+      seedColor: AppColors.primary,
+      brightness: Brightness.dark,
+    ).copyWith(primary: AppColors.primary);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(colorScheme: colorScheme, useMaterial3: true),
+        home: Scaffold(
+          body: Center(
+            child: GlassFilterChip(
+              label: 'Dienst',
+              isSelected: true,
+              onTap: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Text label = tester.widget<Text>(find.text('Dienst'));
+    final Color? labelColor = label.style?.color;
+
+    expect(labelColor, isNotNull);
+    expect(labelColor, isNot(colorScheme.primary));
+    expect(
+      _contrastRatio(labelColor!, colorScheme.primary),
+      greaterThanOrEqualTo(3.0),
+    );
+  });
+}
+
+double _contrastRatio(Color a, Color b) {
+  final double l1 = a.computeLuminance();
+  final double l2 = b.computeLuminance();
+  final double lighter = l1 > l2 ? l1 : l2;
+  final double darker = l1 > l2 ? l2 : l1;
+  return (lighter + 0.05) / (darker + 0.05);
+}


### PR DESCRIPTION
## Summary

- Improve selected `GlassFilterChip` text contrast in dark mode.
- Reuse the existing readable-foreground contrast fallback so selected chips no longer render primary-blue text on a primary-blue tinted chip.
- Add a widget regression test for the selected dark-mode filter chip state.

## Validation

- `flutter pub get`
- `flutter test test/presentation/glass_filter_chip_test.dart test/presentation/glass_bottom_sheet_performance_test.dart`
- `flutter analyze`
- `./gradlew :app:assembleDevDebug`

Known existing Gradle blockers:

- `./gradlew test` fails in `:flutter_local_notifications:testDebugUnitTest` with `ClassReader.java:200`.
- `./gradlew spotlessApply` fails because the Gradle project has no `spotlessApply` task.
- `./gradlew build` fails at the same `:flutter_local_notifications:testDebugUnitTest` failure.
