### PR TITLE
fix: improve bottom sheet performance and picker contrast

### DIFF
--- a/lib/core/constants/glass_tokens.dart
+++ b/lib/core/constants/glass_tokens.dart
@@ -14,7 +14,7 @@ const double glassSurfaceBlurSubtle = 18;
 
 /// Lower than [glassSurfaceBlurDialog] — full-height bottom sheets animate over
 /// the calendar; a lighter blur reduces GPU cost during the modal transition.
-const double glassSurfaceBlurBottomSheet = 16;
+const double glassSurfaceBlurBottomSheet = 8;
 
 // Alpha (tint + border)
 const double glassTintAlphaLight = 0.28;

--- a/lib/presentation/widgets/common/glass_bottom_sheet.dart
+++ b/lib/presentation/widgets/common/glass_bottom_sheet.dart
@@ -13,7 +13,7 @@ const double _kSheetBottomFadeFraction = 0.025;
 /// drag-handle and an optional title. The body is laid out in the same way
 /// as the previous surface-coloured sheet, so existing sheet contents keep
 /// working unchanged.
-class GlassBottomSheet extends StatelessWidget {
+class GlassBottomSheet extends StatefulWidget {
   final String? title;
   final List<Widget> children;
   final double? heightPercentage;
@@ -24,6 +24,7 @@ class GlassBottomSheet extends StatelessWidget {
   /// [heightPercentage] or 80% of the screen, as before.
   final bool shrinkToContent;
   final double backdropBlurSigma;
+  final bool deferExpensiveEffects;
 
   const GlassBottomSheet({
     super.key,
@@ -33,14 +34,93 @@ class GlassBottomSheet extends StatelessWidget {
     this.showHandleBar = true,
     this.shrinkToContent = false,
     this.backdropBlurSigma = glassSurfaceBlurBottomSheet,
+    this.deferExpensiveEffects = true,
   });
+
+  @override
+  State<GlassBottomSheet> createState() => _GlassBottomSheetState();
+}
+
+class _GlassBottomSheetState extends State<GlassBottomSheet> {
+  Animation<double>? _routeAnimation;
+  bool _isRouteSettled = false;
+
+  bool get _shouldTrackRoutePhase {
+    return widget.deferExpensiveEffects;
+  }
+
+  bool get _isSettled {
+    return !_shouldTrackRoutePhase || _isRouteSettled;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _bindRouteAnimation(ModalRoute.of(context)?.animation);
+  }
+
+  @override
+  void didUpdateWidget(covariant GlassBottomSheet oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncSettledState();
+  }
+
+  @override
+  void dispose() {
+    _routeAnimation?.removeStatusListener(_handleRouteAnimationStatus);
+    super.dispose();
+  }
+
+  void _bindRouteAnimation(Animation<double>? animation) {
+    if (_routeAnimation == animation) {
+      _syncSettledState();
+      return;
+    }
+    _routeAnimation?.removeStatusListener(_handleRouteAnimationStatus);
+    _routeAnimation = animation;
+    _routeAnimation?.addStatusListener(_handleRouteAnimationStatus);
+    _syncSettledState();
+  }
+
+  void _handleRouteAnimationStatus(AnimationStatus status) {
+    _setRouteSettled(status == AnimationStatus.completed);
+  }
+
+  void _syncSettledState() {
+    if (!_shouldTrackRoutePhase) {
+      _setRouteSettled(true);
+      return;
+    }
+    final Animation<double>? animation = _routeAnimation;
+    if (animation == null) {
+      _setRouteSettled(true);
+      return;
+    }
+    _setRouteSettled(animation.status == AnimationStatus.completed);
+  }
+
+  void _setRouteSettled(bool value) {
+    if (_isRouteSettled == value) {
+      return;
+    }
+    if (!mounted) {
+      _isRouteSettled = value;
+      return;
+    }
+    setState(() {
+      _isRouteSettled = value;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final double screenHeight = MediaQuery.of(context).size.height;
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
-    if (shrinkToContent) {
+    final bool expensiveEffectsEnabled =
+        !widget.deferExpensiveEffects || _isSettled;
+
+    if (widget.shrinkToContent) {
       return Padding(
         padding: const EdgeInsets.fromLTRB(
           glassSpacingSm,
@@ -51,7 +131,7 @@ class GlassBottomSheet extends StatelessWidget {
         child: ConstrainedBox(
           constraints: BoxConstraints(maxHeight: screenHeight * 0.92),
           child: GlassDialogSurface(
-            backdropBlurSigma: backdropBlurSigma,
+            backdropBlurSigma: widget.backdropBlurSigma,
             borderRadius: const BorderRadius.all(
               Radius.circular(glassSurfaceRadiusLg + glassSpacingSm / 2),
             ),
@@ -63,10 +143,11 @@ class GlassBottomSheet extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    if (showHandleBar) _buildDragHandleBar(isDark: isDark),
-                    if (title != null && title!.isNotEmpty)
+                    if (widget.showHandleBar)
+                      _buildDragHandleBar(isDark: isDark),
+                    if (widget.title != null && widget.title!.isNotEmpty)
                       _buildTitle(context: context, colorScheme: colorScheme),
-                    if (children.isNotEmpty)
+                    if (widget.children.isNotEmpty)
                       Flexible(
                         fit: FlexFit.loose,
                         child: ScrollFadeMask(
@@ -74,12 +155,13 @@ class GlassBottomSheet extends StatelessWidget {
                           // content beneath it.
                           topFadeFraction: _kSheetTopFadeFraction,
                           bottomFadeFraction: _kSheetBottomFadeFraction,
+                          enabled: expensiveEffectsEnabled,
                           child: SingleChildScrollView(
-                            child: children.length == 1
-                                ? children.first
+                            child: widget.children.length == 1
+                                ? widget.children.first
                                 : Column(
                                     mainAxisSize: MainAxisSize.min,
-                                    children: children,
+                                    children: widget.children,
                                   ),
                           ),
                         ),
@@ -93,7 +175,7 @@ class GlassBottomSheet extends StatelessWidget {
         ),
       );
     }
-    final double heightFactor = heightPercentage ?? 0.8;
+    final double heightFactor = widget.heightPercentage ?? 0.8;
     final double height = screenHeight * heightFactor;
     return Padding(
       padding: const EdgeInsets.fromLTRB(
@@ -105,7 +187,7 @@ class GlassBottomSheet extends StatelessWidget {
       child: SizedBox(
         height: height,
         child: GlassDialogSurface(
-          backdropBlurSigma: backdropBlurSigma,
+          backdropBlurSigma: widget.backdropBlurSigma,
           borderRadius: const BorderRadius.all(
             Radius.circular(glassSurfaceRadiusLg + glassSpacingSm / 2),
           ),
@@ -115,25 +197,26 @@ class GlassBottomSheet extends StatelessWidget {
               color: Colors.transparent,
               child: Column(
                 children: [
-                  if (showHandleBar) _buildDragHandleBar(isDark: isDark),
-                  if (title != null && title!.isNotEmpty)
+                  if (widget.showHandleBar) _buildDragHandleBar(isDark: isDark),
+                  if (widget.title != null && widget.title!.isNotEmpty)
                     _buildTitle(context: context, colorScheme: colorScheme),
-                  if (children.isNotEmpty)
+                  if (widget.children.isNotEmpty)
                     Expanded(
                       // Only auto-fade single-child sheets (the common case:
                       // a single ListView/GridView/ScrollView). Multi-child
                       // sheets (e.g. filter + list) must apply ScrollFadeMask
                       // themselves on the actual scrollable element to avoid
                       // fading fixed headers at the top.
-                      child: children.length == 1
+                      child: widget.children.length == 1
                           ? ScrollFadeMask(
                               topFadeFraction: _kSheetTopFadeFraction,
                               bottomFadeFraction: _kSheetBottomFadeFraction,
-                              child: children.first,
+                              enabled: expensiveEffectsEnabled,
+                              child: widget.children.first,
                             )
                           : Column(
                               mainAxisSize: MainAxisSize.min,
-                              children: children,
+                              children: widget.children,
                             ),
                     ),
                   const SizedBox(height: glassSpacingMd),
@@ -180,7 +263,7 @@ class GlassBottomSheet extends StatelessWidget {
           glassSpacingSm,
         ),
         child: Text(
-          title!,
+          widget.title!,
           textAlign: TextAlign.start,
           style: Theme.of(context).textTheme.headlineSmall?.copyWith(
             fontWeight: FontWeight.w700,

--- a/lib/presentation/widgets/common/glass_button_surface.dart
+++ b/lib/presentation/widgets/common/glass_button_surface.dart
@@ -13,6 +13,8 @@ class GlassButtonSurface extends StatelessWidget {
   final double? width;
   final double opacity;
   final AlignmentGeometry alignment;
+  final double? tintOpacity;
+  final double? borderOpacity;
 
   const GlassButtonSurface({
     super.key,
@@ -26,6 +28,8 @@ class GlassButtonSurface extends StatelessWidget {
     this.width,
     this.opacity = 1.0,
     this.alignment = Alignment.center,
+    this.tintOpacity,
+    this.borderOpacity,
   });
 
   @override
@@ -34,8 +38,11 @@ class GlassButtonSurface extends StatelessWidget {
     final Widget content = GlassContainer(
       borderRadius: borderRadius,
       blurSigma: glassSurfaceBlurDefault,
-      tintOpacity: isDark ? glassTintAlphaDark : glassTintAlphaLight,
-      borderOpacity: isDark ? glassBorderAlphaDark : glassBorderAlphaLight,
+      tintOpacity:
+          tintOpacity ?? (isDark ? glassTintAlphaDark : glassTintAlphaLight),
+      borderOpacity:
+          borderOpacity ??
+          (isDark ? glassBorderAlphaDark : glassBorderAlphaLight),
       padding: padding,
       child: Material(
         color: Colors.transparent,

--- a/lib/presentation/widgets/common/glass_picker_controls.dart
+++ b/lib/presentation/widgets/common/glass_picker_controls.dart
@@ -170,7 +170,7 @@ class GlassPickerTile extends StatelessWidget {
     } else if (isFocused) {
       background = primary.withValues(alpha: isDark ? 0.45 : 0.38);
       borderColor = Colors.white.withValues(alpha: isDark ? 0.28 : 0.55);
-      textColor = colorScheme.onPrimary;
+      textColor = isDark ? colorScheme.onSurface : colorScheme.onPrimary;
       fontWeight = FontWeight.w700;
       boxShadow = <BoxShadow>[
         BoxShadow(

--- a/lib/presentation/widgets/common/scroll_fade_mask.dart
+++ b/lib/presentation/widgets/common/scroll_fade_mask.dart
@@ -14,16 +14,21 @@ class ScrollFadeMask extends StatelessWidget {
   final Widget child;
   final double topFadeFraction;
   final double bottomFadeFraction;
+  final bool enabled;
 
   const ScrollFadeMask({
     super.key,
     required this.child,
     this.topFadeFraction = 0.05,
     this.bottomFadeFraction = 0.06,
+    this.enabled = true,
   });
 
   @override
   Widget build(BuildContext context) {
+    if (!enabled) {
+      return child;
+    }
     return ShaderMask(
       blendMode: BlendMode.dstIn,
       shaderCallback: (Rect rect) {

--- a/lib/presentation/widgets/common/whats_new_host.dart
+++ b/lib/presentation/widgets/common/whats_new_host.dart
@@ -12,6 +12,7 @@ import 'package:dienstplan/presentation/widgets/common/glass_button_surface.dart
 Future<void> showWhatsNewDialog(BuildContext context) async {
   final AppLocalizations l10n = AppLocalizations.of(context);
   final ColorScheme colorScheme = Theme.of(context).colorScheme;
+  final bool isDark = Theme.of(context).brightness == Brightness.dark;
   await GlassAppDialog.show<void>(
     context: context,
     barrierDismissible: true,
@@ -24,6 +25,10 @@ Future<void> showWhatsNewDialog(BuildContext context) async {
         borderRadius: glassSurfaceRadiusSm,
         height: 48,
         fullWidth: true,
+        tintOpacity: isDark
+            ? glassTintAlphaActiveDark
+            : glassTintAlphaActiveLight,
+        borderOpacity: glassBorderAlphaActive,
         child: Center(
           child: Text(
             l10n.whatsNewGotIt,

--- a/test/presentation/glass_bottom_sheet_performance_test.dart
+++ b/test/presentation/glass_bottom_sheet_performance_test.dart
@@ -1,4 +1,5 @@
 import 'package:dienstplan/presentation/widgets/common/glass_bottom_sheet.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_dialog_surface.dart';
 import 'package:dienstplan/presentation/widgets/common/glass_filter_chip.dart';
 import 'package:dienstplan/presentation/widgets/common/glass_picker_controls.dart';
 import 'package:flutter/material.dart';
@@ -34,5 +35,116 @@ void main() {
       filters.where((BackdropFilter filter) => !filter.enabled),
       isNotEmpty,
     );
+  });
+
+  testWidgets('bottom sheet uses the same light root blur while opening', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return TextButton(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  backgroundColor: Colors.transparent,
+                  builder: (BuildContext context) {
+                    return GlassBottomSheet(
+                      children: <Widget>[
+                        ListView(children: const <Widget>[Text('Content')]),
+                      ],
+                    );
+                  },
+                );
+              },
+              child: const Text('Open'),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    Iterable<BackdropFilter> filters = tester.widgetList(
+      find.byType(BackdropFilter),
+    );
+    expect(
+      filters.where((BackdropFilter filter) => filter.enabled),
+      hasLength(1),
+    );
+    expect(
+      tester.widget<GlassDialogSurface>(find.byType(GlassDialogSurface)),
+      isA<GlassDialogSurface>().having(
+        (GlassDialogSurface surface) => surface.backdropBlurSigma,
+        'backdropBlurSigma',
+        8,
+      ),
+    );
+    expect(find.byType(ShaderMask), findsNothing);
+
+    await tester.pumpAndSettle();
+
+    filters = tester.widgetList(find.byType(BackdropFilter));
+    expect(
+      filters.where((BackdropFilter filter) => filter.enabled),
+      hasLength(1),
+    );
+    expect(
+      tester.widget<GlassDialogSurface>(find.byType(GlassDialogSurface)),
+      isA<GlassDialogSurface>().having(
+        (GlassDialogSurface surface) => surface.backdropBlurSigma,
+        'backdropBlurSigma',
+        8,
+      ),
+    );
+    expect(find.byType(ShaderMask), findsOneWidget);
+  });
+
+  testWidgets('bottom sheet shows heavy content while modal route opens', (
+    WidgetTester tester,
+  ) async {
+    const Key heavyContentKey = Key('heavy-content');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return TextButton(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  backgroundColor: Colors.transparent,
+                  builder: (BuildContext context) {
+                    return const GlassBottomSheet(
+                      children: <Widget>[
+                        Text('Header'),
+                        Text('Heavy content', key: heavyContentKey),
+                      ],
+                    );
+                  },
+                );
+              },
+              child: const Text('Open'),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    expect(find.text('Header'), findsOneWidget);
+    expect(find.byKey(heavyContentKey), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Header'), findsOneWidget);
+    expect(find.byKey(heavyContentKey), findsOneWidget);
   });
 }

--- a/test/presentation/glass_picker_tile_test.dart
+++ b/test/presentation/glass_picker_tile_test.dart
@@ -1,0 +1,38 @@
+import 'package:dienstplan/presentation/widgets/common/glass_picker_controls.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('focused picker tiles keep readable text in dark mode', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: Column(
+            children: <Widget>[
+              GlassPickerTile(
+                label: 'Jan',
+                isFocused: true,
+                isCurrent: false,
+                onTap: () {},
+              ),
+              GlassPickerTile(
+                label: '2026',
+                isFocused: true,
+                isCurrent: false,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Color expectedColor = ThemeData.dark().colorScheme.onSurface;
+
+    expect(tester.widget<Text>(find.text('Jan')).style?.color, expectedColor);
+    expect(tester.widget<Text>(find.text('2026')).style?.color, expectedColor);
+  });
+}

--- a/test/presentation/whats_new_dialog_test.dart
+++ b/test/presentation/whats_new_dialog_test.dart
@@ -1,0 +1,50 @@
+import 'package:dienstplan/core/constants/glass_tokens.dart';
+import 'package:dienstplan/core/l10n/app_localizations.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_button_surface.dart';
+import 'package:dienstplan/presentation/widgets/common/glass_container.dart';
+import 'package:dienstplan/presentation/widgets/common/whats_new_host.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('whats new dialog action has stronger dark mode contrast', (
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1200, 1600);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        locale: const Locale('de'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (BuildContext context) {
+            return TextButton(
+              onPressed: () {
+                showWhatsNewDialog(context);
+              },
+              child: const Text('Open'),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final Finder actionSurface = find.descendant(
+      of: find.byType(GlassButtonSurface),
+      matching: find.byType(GlassContainer),
+    );
+    final GlassContainer container = tester.widget<GlassContainer>(
+      actionSurface,
+    );
+
+    expect(container.tintOpacity, greaterThan(glassTintAlphaDark));
+    expect(container.borderOpacity, greaterThan(glassBorderAlphaDark));
+  });
+}


### PR DESCRIPTION

## Summary

- Reduce the shared bottom sheet root blur from 16 to 8 while keeping the glass appearance intact.
- Keep bottom sheet content visible immediately and only defer the scroll fade mask until the route animation settles.
- Strengthen the changelog dialog action surface in dark mode so the primary button has better contrast.
- Improve selected month and year readability in the dark-mode month/year picker.
- Add widget coverage for bottom sheet blur/content behavior, changelog button contrast, and focused picker tile text contrast.

## Validation

- `flutter test`
- `flutter test test/presentation/glass_picker_tile_test.dart`
- `flutter test test/presentation/glass_bottom_sheet_performance_test.dart test/presentation/whats_new_dialog_test.dart`
- `flutter analyze lib/presentation/widgets/common/glass_picker_controls.dart test/presentation/glass_picker_tile_test.dart lib/core/constants/glass_tokens.dart lib/presentation/widgets/common/glass_bottom_sheet.dart lib/presentation/widgets/common/glass_button_surface.dart lib/presentation/widgets/common/scroll_fade_mask.dart lib/presentation/widgets/common/whats_new_host.dart test/presentation/glass_bottom_sheet_performance_test.dart test/presentation/whats_new_dialog_test.dart`
- `dart format --output=none --set-exit-if-changed .`
- `git diff --check`

## Known existing blockers

- Full `flutter analyze` still reports the existing `lib/presentation/widgets/screens/settings/components/dialogs/app_dialog.dart:22` `use_null_aware_elements` info.
- `./gradlew spotlessApply` is not available in the Android Gradle project.
- `./gradlew test` fails in the external `:flutter_local_notifications:testDebugUnitTest` task with `ClassReader.java:200`.
- `./gradlew build` fails in the external `:flutter_local_notifications:lintDebug` task with `MissingPermission` in the Pub cache plugin source.
