### PR TITLE
fix: update android gradle toolchain

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           
       - name: 📱 Setup Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,12 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
           restore-keys: ${{ runner.os }}-pub-
 
+      - name: ☕ Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
       - name: 📱 Setup Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,10 @@ android {
     }
 
     kotlin {
-        jvmToolchain(21)
+        jvmToolchain(25)
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+        }
     }
 
     buildFeatures {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -32,8 +31,8 @@ android {
         jvmToolchain(21)
     }
 
-    sourceSets {
-        getByName("main").java.srcDirs("src/main/kotlin")
+    buildFeatures {
+        resValues = true
     }
 
     defaultConfig {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,14 +5,19 @@ allprojects {
     }
 }
 
-rootProject.buildDir = file("../build")
+val newBuildDir =
+    rootProject.layout.buildDirectory
+        .dir("../build")
+        .get()
+rootProject.layout.buildDirectory.value(newBuildDir)
+
 subprojects {
-    project.buildDir = file("${rootProject.buildDir}/${project.name}")
+    project.layout.buildDirectory.value(newBuildDir.dir(project.name))
 }
 subprojects {
     project.evaluationDependsOn(":app")
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,3 +6,7 @@ android.enableJetifier=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.daemon=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -20,8 +20,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.13.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.2.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.10" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Description
Updates the Android Gradle toolchain and removes the app-level Kotlin Gradle Plugin application so Flutter no longer reports the app project itself as applying KGP.

Changes:
- Update Android Gradle Plugin to 9.2.1 and Kotlin Gradle Plugin declaration to 2.3.10.
- Update Gradle wrapper distribution to 9.4.1.
- Keep Flutter's compatibility flags for built-in Kotlin/new DSL and enable generated res values for flavor app names.
- Replace deprecated root buildDir usage with layout.buildDirectory.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
N/A

## Additional Context
Verification:
- PASS: flutter analyze
- PASS: flutter test
- PASS: flutter build apk --flavor dev --debug
- FAIL: ./gradlew test --console=plain, existing external :flutter_local_notifications:testDebugUnitTest ClassReader.java:200 failures
- FAIL: ./gradlew spotlessApply --console=plain, no spotlessApply task exists in this Android/Flutter project
- FAIL: ./gradlew build --console=plain, same external :flutter_local_notifications:testDebugUnitTest ClassReader.java:200 failures

Remaining Flutter KGP warning is limited to external plugins file_saver and sentry_flutter; pub outdated reports both are already at the latest resolvable versions.