### PR TITLE
fix: restore release build outputs

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -84,12 +84,15 @@ jobs:
 
       - name: 🔧 Patch Podfile for CI signing
         run: |
-          # Füge Ruby-Code-Block zum Podfile hinzu, falls noch nicht vorhanden
+          if [ ! -f ios/Podfile ]; then
+            echo "No Podfile found; skipping CocoaPods signing patch."
+            exit 0
+          fi
+
           if ! grep -q "post_install do |installer|" ios/Podfile; then
             echo -e '\npost_install do |installer|\nend' >> ios/Podfile
           fi
       
-          # Füge die Signierungs-Settings für alle Pods ein
           sed -i '' '/post_install do |installer|/a\
             installer.pods_project.targets.each do |target|\
               target.build_configurations.each do |config|\

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -84,25 +84,6 @@ android {
         }
     }
 
-    // Custom APK naming
-    applicationVariants.all {
-        outputs.all {
-            val versionName = defaultConfig.versionName
-            val versionCode = defaultConfig.versionCode
-            val buildType = buildType.name
-            val flavorName = flavorName
-            
-            if (buildType == "release") {
-                (this as? com.android.build.gradle.internal.api.BaseVariantOutputImpl)?.outputFileName = 
-                    "dienstplan-${versionName}-${flavorName}-${versionCode}.apk"
-            } else {
-                (this as? com.android.build.gradle.internal.api.BaseVariantOutputImpl)?.outputFileName = 
-                    "dienstplan-${versionName}-${flavorName}-${versionCode}-${buildType}.apk"
-            }
-        }
-    }
-
-    // Custom AAB naming
     bundle {
         language {
             enableSplit = false
@@ -112,21 +93,6 @@ android {
         }
         abi {
             enableSplit = true
-        }
-    }
-    
-    // Set custom AAB filename
-    applicationVariants.all {
-        if (buildType.name == "release") {
-            outputs.all {
-                if (name.contains("Bundle")) {
-                    val versionName = defaultConfig.versionName
-                    val versionCode = defaultConfig.versionCode
-                    val flavorName = flavorName
-                    (this as? com.android.build.gradle.internal.api.BaseVariantOutputImpl)?.outputFileName = 
-                        "dienstplan-${versionName}-${flavorName}-${versionCode}.aab"
-                }
-            }
         }
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,19 +5,20 @@ allprojects {
     }
 }
 
-val newBuildDir =
+val newBuildDir: Directory =
     rootProject.layout.buildDirectory
-        .dir("../build")
+        .dir("../../build")
         .get()
 rootProject.layout.buildDirectory.value(newBuildDir)
 
 subprojects {
-    project.layout.buildDirectory.value(newBuildDir.dir(project.name))
+    val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
+    project.layout.buildDirectory.value(newSubprojectBuildDir)
 }
 subprojects {
     project.evaluationDependsOn(":app")
 }
 
-tasks.register("clean", Delete::class) {
+tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## Description
Fixes the failed `v0.17.1` Android and iOS release pipelines.

Root causes:
- Android Gradle outputs were being written under `android/build`, while Flutter expected release artifacts under the repository-level `build` directory.
- The Android app also overrode APK/AAB names even though the release workflow expects Flutter's standard `app-prod-release` artifact names and renames them later.
- The iOS workflow tried to patch `ios/Podfile`, but the current Flutter iOS project has no Podfile.

Changes:
- Align Android Gradle build directories with the current Flutter template (`../../build`).
- Remove custom APK/AAB output naming so Flutter and the release workflow see the standard artifact paths.
- Skip the iOS CocoaPods signing patch when `ios/Podfile` is absent.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Not applicable.

## Additional Context
Validation:
- `flutter pub get` passed.
- `ANDROID_KEYSTORE_BASE64=dummy ANDROID_KEYSTORE_PASSWORD=testpass ANDROID_KEY_ALIAS=test ANDROID_KEY_PASSWORD=testpass flutter build apk --flavor prod --release --build-number=82` passed and produced `build/app/outputs/flutter-apk/app-prod-release.apk`.
- `ANDROID_KEYSTORE_BASE64=dummy ANDROID_KEYSTORE_PASSWORD=testpass ANDROID_KEY_ALIAS=test ANDROID_KEY_PASSWORD=testpass flutter build appbundle --flavor prod --release --build-number=82` passed and produced `build/app/outputs/bundle/prodRelease/app-prod-release.aab`.
- `git diff --check` passed.

Known existing issues while running required Gradle commands:
- `./gradlew test` fails in `:flutter_local_notifications:testDebugUnitTest` with `IllegalArgumentException at ClassReader.java:200`.
- `./gradlew spotlessApply` fails because the task is not defined in the Android Gradle project.
- `./gradlew build` fails in `:flutter_local_notifications:testDebugUnitTest` and also reports lint errors inside `flutter_local_notifications-22.0.1`.
