### PR TITLE
fix: scope ios release signing

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -109,15 +109,68 @@ jobs:
           pod install
           cd ..
       
-      - name: 📝 Create CI signing config
+      - name: 📝 Patch Runner signing settings
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PROFILE_NAME: ${{ secrets.PROFILE_NAME }}
         run: |
-          cat > ios/ci-signing.xcconfig <<EOF
-          CODE_SIGN_STYLE = Manual
-          DEVELOPMENT_TEAM = ${{ secrets.APPLE_TEAM_ID }}
-          PROVISIONING_PROFILE_SPECIFIER = ${{ secrets.PROFILE_NAME }}
-          CODE_SIGN_IDENTITY = Apple Distribution
-          OTHER_CODE_SIGN_FLAGS = --keychain build.keychain
-          EOF
+          python3 <<'PYTHON'
+          import os
+          import re
+          import sys
+
+          project_path = "ios/Runner.xcodeproj/project.pbxproj"
+          with open(project_path, encoding="utf-8") as project_file:
+              project = project_file.read()
+
+          release_config_pattern = re.compile(
+              r"(\t\t97C147071CF9000F007C117D /\* Release \*/ = \{\n"
+              r"\t\t\tisa = XCBuildConfiguration;\n"
+              r"\t\t\tbaseConfigurationReference = .*?\n"
+              r"\t\t\tbuildSettings = \{\n)"
+              r"(.*?)"
+              r"(\n\t\t\t\};\n\t\t\tname = Release;\n\t\t\};)",
+              re.DOTALL,
+          )
+
+          match = release_config_pattern.search(project)
+          if match is None:
+              sys.exit("Failed to find Runner Release build configuration")
+
+          def pbx_quote(value):
+              return '"' + str(value).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+          settings = {
+              "CODE_SIGN_STYLE": "Manual",
+              "DEVELOPMENT_TEAM": os.environ["APPLE_TEAM_ID"],
+              "PROVISIONING_PROFILE_SPECIFIER": pbx_quote(os.environ["PROFILE_NAME"]),
+              "CODE_SIGN_IDENTITY[sdk=iphoneos*]": pbx_quote("Apple Distribution"),
+              "OTHER_CODE_SIGN_FLAGS": pbx_quote("--keychain build.keychain"),
+          }
+
+          build_settings = match.group(2)
+          for key, value in settings.items():
+              pbx_key = pbx_quote(key) if "[" in key else key
+              line = f"\t\t\t\t{pbx_key} = {value};"
+              setting_pattern = re.compile(
+                  rf"^\t\t\t\t{re.escape(pbx_key)} = .*;$",
+                  re.MULTILINE,
+              )
+              if setting_pattern.search(build_settings):
+                  build_settings = setting_pattern.sub(line, build_settings)
+              else:
+                  build_settings = f"{build_settings}\n{line}"
+
+          project = (
+              project[: match.start()]
+              + match.group(1)
+              + build_settings
+              + match.group(3)
+              + project[match.end() :]
+          )
+          with open(project_path, "w", encoding="utf-8") as project_file:
+              project_file.write(project)
+          PYTHON
       
       - name: 🏗️ Archive iOS App
         run: |
@@ -127,7 +180,6 @@ jobs:
             -scheme Runner \
             -configuration Release \
             -archivePath ../build/Runner.xcarchive \
-            -xcconfig ci-signing.xcconfig \
             archive
 
       - name: 📝 Generate ExportOptions.plist


### PR DESCRIPTION
## Description
Fixes the next iOS release failure seen in run `28331019800`, job `83929073384`.

Root cause:
- The iOS archive step passed manual signing settings through `-xcconfig`.
- Xcode applies that xcconfig broadly, including Swift Package plugin targets generated by Flutter 3.44.
- Those package targets do not support provisioning profiles, so archive failed with errors like `package_info_plus_package_info_plus does not support provisioning profiles`.

Changes:
- Patch manual signing settings only into the Runner Release build configuration at CI runtime.
- Remove the global `-xcconfig ci-signing.xcconfig` archive override.
- Keep the App Store export options unchanged.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Not applicable.

## Additional Context
Validation:
- Inspected failing iOS release job `83929073384`; failure is in `Archive iOS App` after the previous Podfile guard succeeds.
- Reproduced the workflow patch script locally with dummy signing values and confirmed it modifies only the Runner Release build configuration in `ios/Runner.xcodeproj/project.pbxproj`.
- Parsed `.github/workflows/ios-release.yml` as YAML successfully.
- `git diff --check` passed.

This change cannot fully archive locally because the signing certificate/profile secrets are only available in GitHub Actions.
