### PR TITLE
fix: keep calendar duty chips in full view

### DIFF
--- a/lib/core/constants/calendar_config.dart
+++ b/lib/core/constants/calendar_config.dart
@@ -62,12 +62,6 @@ class CalendarConfig {
   /// Negative spread keeps the penumbra tight so the header stays airy.
   static const double kCalendarHeaderShadowSpread = -3.0;
 
-  /// When the day cell is at most this tall, the calendar day uses the compact
-  /// stripe layout instead of text chips. IME / tight layouts can yield
-  /// ~90–100px cell height while still too short for a full chip stack, so this
-  /// is above the nominal [kCalendarDayHeight] to avoid [RenderFlex] overflow.
-  static const double kCalendarDayCompactDutyStripesMaxHeight = 100.0;
-
   /// Max height for the month table in split layout (day list below). Kept
   /// low enough that row height yields compact duty stripes like IME/keyboard
   /// shrink, not full chips.

--- a/lib/presentation/widgets/screens/calendar/builders/calendar_day_builders.dart
+++ b/lib/presentation/widgets/screens/calendar/builders/calendar_day_builders.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart' as tc;
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart';
 import 'package:dienstplan/presentation/widgets/screens/calendar/components/memoized_calendar_day.dart';
 import 'package:dienstplan/presentation/widgets/screens/calendar/date_selector/animated_calendar_day.dart';
 import 'package:dienstplan/core/constants/calendar_config.dart';
@@ -8,7 +9,11 @@ import 'package:dienstplan/core/constants/calendar_config.dart';
 ///
 /// Selection is handled exclusively by [tc.TableCalendar.onDaySelected].
 class CalendarDayBuilders {
-  static tc.CalendarBuilders create({double? cellHeight}) {
+  static tc.CalendarBuilders create({
+    double? cellHeight,
+    required CalendarDayRenderingData renderingData,
+    required bool useCompactDutyStripes,
+  }) {
     final double effectiveHeight =
         cellHeight ?? CalendarConfig.kCalendarDayHeight;
     return tc.CalendarBuilders(
@@ -20,6 +25,8 @@ class CalendarDayBuilders {
               dayType: CalendarDayType.default_,
               width: CalendarConfig.kCalendarDayWidth,
               height: effectiveHeight,
+              renderingData: renderingData,
+              useCompactDutyStripes: useCompactDutyStripes,
             );
           },
       outsideBuilder:
@@ -30,6 +37,8 @@ class CalendarDayBuilders {
               dayType: CalendarDayType.outside,
               width: CalendarConfig.kCalendarDayWidth,
               height: effectiveHeight,
+              renderingData: renderingData,
+              useCompactDutyStripes: useCompactDutyStripes,
             );
           },
       selectedBuilder:
@@ -40,6 +49,8 @@ class CalendarDayBuilders {
               dayType: CalendarDayType.selected,
               width: CalendarConfig.kCalendarDayWidth,
               height: effectiveHeight,
+              renderingData: renderingData,
+              useCompactDutyStripes: useCompactDutyStripes,
             );
           },
       todayBuilder: (BuildContext context, DateTime day, DateTime focusedDay) {
@@ -49,6 +60,8 @@ class CalendarDayBuilders {
           dayType: CalendarDayType.today,
           width: CalendarConfig.kCalendarDayWidth,
           height: effectiveHeight,
+          renderingData: renderingData,
+          useCompactDutyStripes: useCompactDutyStripes,
         );
       },
     );

--- a/lib/presentation/widgets/screens/calendar/calendar_view/calendar_view.dart
+++ b/lib/presentation/widgets/screens/calendar/calendar_view/calendar_view.dart
@@ -94,6 +94,7 @@ class _CalendarViewState extends ConsumerState<CalendarView> {
                                             child: CalendarTable(
                                               onPageChanged: (_) {},
                                               onDaySelected: _handleDaySelected,
+                                              useCompactDutyStripes: true,
                                             ),
                                           ),
                                         ),
@@ -113,6 +114,7 @@ class _CalendarViewState extends ConsumerState<CalendarView> {
                               child: CalendarTable(
                                 onPageChanged: (_) {},
                                 onDaySelected: _handleDaySelected,
+                                useCompactDutyStripes: false,
                               ),
                             ),
                           ),

--- a/lib/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart
+++ b/lib/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart
@@ -1,0 +1,238 @@
+import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
+import 'package:dienstplan/domain/entities/duty_type.dart';
+import 'package:dienstplan/domain/entities/schedule.dart';
+import 'package:dienstplan/presentation/state/calendar/calendar_partner_visibility_notifier.dart';
+import 'package:dienstplan/presentation/state/schedule/schedule_coordinator_notifier.dart';
+import 'package:dienstplan/presentation/state/school_holidays/school_holidays_notifier.dart';
+import 'package:dienstplan/presentation/state/school_holidays/school_holidays_ui_state.dart';
+import 'package:dienstplan/presentation/state/settings/settings_notifier.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_schedule_lookup.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/duty_group_fallback.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class CalendarTableRenderingData {
+  final DateTime focusedDay;
+  final DateTime? selectedDay;
+  final String? activeConfigName;
+
+  const CalendarTableRenderingData({
+    required this.focusedDay,
+    required this.selectedDay,
+    required this.activeConfigName,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is CalendarTableRenderingData &&
+            other.focusedDay == focusedDay &&
+            other.selectedDay == selectedDay &&
+            other.activeConfigName == activeConfigName;
+  }
+
+  @override
+  int get hashCode => Object.hash(focusedDay, selectedDay, activeConfigName);
+}
+
+class CalendarDayRenderingData {
+  final CalendarDayScheduleLookup? scheduleLookup;
+  final String? activeConfigName;
+  final String? preferredDutyGroup;
+  final String? myDutyGroup;
+  final String? partnerConfigName;
+  final String? partnerDutyGroup;
+  final bool isPartnerVisible;
+  final int? partnerAccentColorValue;
+  final int? myAccentColorValue;
+  final int? holidayAccentColorValue;
+  final Map<String, DutyType>? activeDutyTypes;
+  final List<DutyScheduleConfig> configs;
+  final SchoolHolidaysUiState? holidaysState;
+
+  const CalendarDayRenderingData({
+    required this.scheduleLookup,
+    required this.activeConfigName,
+    required this.preferredDutyGroup,
+    required this.myDutyGroup,
+    required this.partnerConfigName,
+    required this.partnerDutyGroup,
+    required this.isPartnerVisible,
+    required this.partnerAccentColorValue,
+    required this.myAccentColorValue,
+    required this.holidayAccentColorValue,
+    required this.activeDutyTypes,
+    required this.configs,
+    required this.holidaysState,
+  });
+
+  String? get effectivePartnerConfigName {
+    return isPartnerVisible ? partnerConfigName : null;
+  }
+
+  String? get effectivePartnerGroup {
+    return isPartnerVisible ? partnerDutyGroup : null;
+  }
+
+  String? get effectiveMyGroup {
+    return computeEffectiveMyGroup(
+      preferredGroup: preferredDutyGroup,
+      myDutyGroup: myDutyGroup,
+    );
+  }
+
+  Map<String, DutyType>? get partnerDutyTypes {
+    final String? partnerName = effectivePartnerConfigName;
+    if (partnerName == null || partnerName.isEmpty) {
+      return null;
+    }
+    for (final DutyScheduleConfig config in configs) {
+      if (config.name == partnerName) {
+        return config.dutyTypes;
+      }
+    }
+    return null;
+  }
+
+  int signatureForMonth(DateTime day) {
+    return scheduleLookup?.signatureForMonth(day) ?? 0;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is CalendarDayRenderingData &&
+            other.scheduleLookup == scheduleLookup &&
+            other.activeConfigName == activeConfigName &&
+            other.preferredDutyGroup == preferredDutyGroup &&
+            other.myDutyGroup == myDutyGroup &&
+            other.partnerConfigName == partnerConfigName &&
+            other.partnerDutyGroup == partnerDutyGroup &&
+            other.isPartnerVisible == isPartnerVisible &&
+            other.partnerAccentColorValue == partnerAccentColorValue &&
+            other.myAccentColorValue == myAccentColorValue &&
+            other.holidayAccentColorValue == holidayAccentColorValue &&
+            mapEquals(other.activeDutyTypes, activeDutyTypes) &&
+            listEquals(other.configs, configs) &&
+            other.holidaysState == holidaysState;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    scheduleLookup,
+    activeConfigName,
+    preferredDutyGroup,
+    myDutyGroup,
+    partnerConfigName,
+    partnerDutyGroup,
+    isPartnerVisible,
+    partnerAccentColorValue,
+    myAccentColorValue,
+    holidayAccentColorValue,
+    activeDutyTypes == null
+        ? null
+        : Object.hashAll(
+            activeDutyTypes!.entries.map(
+              (entry) => Object.hash(entry.key, entry.value),
+            ),
+          ),
+    Object.hashAll(configs),
+    holidaysState,
+  );
+}
+
+final calendarTableRenderingDataProvider = Provider<CalendarTableRenderingData>(
+  (ref) {
+    final DateTime now = DateTime.now();
+    final DateTime? focusedDay = ref.watch(
+      scheduleCoordinatorProvider.select((state) => state.value?.focusedDay),
+    );
+    final DateTime? selectedDay = ref.watch(
+      scheduleCoordinatorProvider.select((state) => state.value?.selectedDay),
+    );
+    final String? activeConfigName = ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.activeConfigName,
+      ),
+    );
+
+    return CalendarTableRenderingData(
+      focusedDay: focusedDay ?? now,
+      selectedDay: selectedDay,
+      activeConfigName: activeConfigName,
+    );
+  },
+);
+
+final calendarDayScheduleLookupProvider = Provider<CalendarDayScheduleLookup>((
+  ref,
+) {
+  final List<Schedule> schedules = ref.watch(
+    scheduleCoordinatorProvider.select(
+      (state) => state.value?.schedules ?? const <Schedule>[],
+    ),
+  );
+  return CalendarDayScheduleLookup(schedules);
+});
+
+final calendarDayRenderingDataProvider = Provider<CalendarDayRenderingData>((
+  ref,
+) {
+  final String? myDutyGroup = ref.watch(
+    settingsProvider.select((s) => s.value?.myDutyGroup),
+  );
+  final int? holidayAccentColorValue = ref.watch(
+    settingsProvider.select((s) => s.value?.holidayAccentColorValue),
+  );
+  final CalendarDayScheduleLookup scheduleLookup = ref.watch(
+    calendarDayScheduleLookupProvider,
+  );
+
+  return CalendarDayRenderingData(
+    scheduleLookup: scheduleLookup,
+    activeConfigName: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.activeConfigName,
+      ),
+    ),
+    preferredDutyGroup: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.preferredDutyGroup,
+      ),
+    ),
+    myDutyGroup: myDutyGroup,
+    partnerConfigName: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.partnerConfigName,
+      ),
+    ),
+    partnerDutyGroup: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.partnerDutyGroup,
+      ),
+    ),
+    isPartnerVisible: ref.watch(calendarPartnerVisibilityProvider),
+    partnerAccentColorValue: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.partnerAccentColorValue,
+      ),
+    ),
+    myAccentColorValue: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.myAccentColorValue,
+      ),
+    ),
+    holidayAccentColorValue: holidayAccentColorValue,
+    activeDutyTypes: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.activeConfig?.dutyTypes,
+      ),
+    ),
+    configs: ref.watch(
+      scheduleCoordinatorProvider.select(
+        (state) => state.value?.configs ?? const <DutyScheduleConfig>[],
+      ),
+    ),
+    holidaysState: ref.watch(schoolHolidaysProvider.select((s) => s.value)),
+  );
+});

--- a/lib/presentation/widgets/screens/calendar/components/memoized_calendar_day.dart
+++ b/lib/presentation/widgets/screens/calendar/components/memoized_calendar_day.dart
@@ -1,53 +1,42 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dienstplan/presentation/widgets/screens/calendar/date_selector/animated_calendar_day.dart';
-import 'package:dienstplan/presentation/state/schedule/schedule_coordinator_notifier.dart';
-import 'package:dienstplan/presentation/state/school_holidays/school_holidays_notifier.dart';
 import 'package:dienstplan/core/constants/calendar_config.dart';
 import 'package:dienstplan/core/utils/duty_type_display.dart';
-import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
 import 'package:dienstplan/domain/entities/duty_type.dart';
 import 'package:dienstplan/domain/entities/schedule.dart';
-import 'package:dienstplan/presentation/state/calendar/calendar_partner_visibility_notifier.dart';
-import 'package:dienstplan/presentation/state/settings/settings_notifier.dart';
 import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_schedule_lookup.dart';
-import 'package:dienstplan/presentation/widgets/screens/calendar/components/duty_group_fallback.dart';
-
-final calendarDayScheduleLookupProvider = Provider<CalendarDayScheduleLookup>((
-  ref,
-) {
-  final List<Schedule> schedules = ref.watch(
-    scheduleCoordinatorProvider.select(
-      (state) => state.value?.schedules ?? const <Schedule>[],
-    ),
-  );
-  return CalendarDayScheduleLookup(schedules);
-});
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart';
 
 /// Optimized calendar day widget with memoization and selective provider watching
-class MemoizedCalendarDay extends ConsumerWidget {
+class MemoizedCalendarDay extends StatelessWidget {
   final DateTime day;
   final CalendarDayType dayType;
   final double? width;
   final double? height;
   final VoidCallback? onDaySelected;
+  final CalendarDayRenderingData renderingData;
+  final bool useCompactDutyStripes;
 
   const MemoizedCalendarDay({
     super.key,
     required this.day,
     required this.dayType,
+    required this.renderingData,
+    this.useCompactDutyStripes = false,
     this.width,
     this.height,
     this.onDaySelected,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return RepaintBoundary(
       child: _MemoizedCalendarDayContent(
         day: day,
         dayType: dayType,
+        renderingData: renderingData,
+        useCompactDutyStripes: useCompactDutyStripes,
         width: width,
         height: height,
         onDaySelected: onDaySelected,
@@ -56,9 +45,11 @@ class MemoizedCalendarDay extends ConsumerWidget {
   }
 }
 
-class _MemoizedCalendarDayContent extends ConsumerWidget {
+class _MemoizedCalendarDayContent extends StatelessWidget {
   final DateTime day;
   final CalendarDayType dayType;
+  final CalendarDayRenderingData renderingData;
+  final bool useCompactDutyStripes;
   final double? width;
   final double? height;
   final VoidCallback? onDaySelected;
@@ -66,76 +57,16 @@ class _MemoizedCalendarDayContent extends ConsumerWidget {
   const _MemoizedCalendarDayContent({
     required this.day,
     required this.dayType,
+    required this.renderingData,
+    required this.useCompactDutyStripes,
     this.width,
     this.height,
     this.onDaySelected,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final CalendarDayScheduleLookup scheduleLookup = ref.watch(
-      calendarDayScheduleLookupProvider,
-    );
-
-    final activeConfig = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.activeConfigName,
-      ),
-    );
-
-    final preferredGroup = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.preferredDutyGroup,
-      ),
-    );
-
-    final partnerConfigName = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.partnerConfigName,
-      ),
-    );
-
-    final partnerGroup = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.partnerDutyGroup,
-      ),
-    );
-
-    // View-only visibility override: hiding the partner in the calendar
-    // must not mutate the persisted partner configuration.
-    final bool partnerVisible = ref.watch(calendarPartnerVisibilityProvider);
-    final String? effectivePartnerConfigName = partnerVisible
-        ? partnerConfigName
-        : null;
-    final String? effectivePartnerGroup = partnerVisible ? partnerGroup : null;
-
-    final selectedDay = ref.watch(
-      scheduleCoordinatorProvider.select((state) => state.value?.selectedDay),
-    );
-
-    final partnerAccentColor = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.partnerAccentColorValue,
-      ),
-    );
-
-    final myAccentColor = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.myAccentColorValue,
-      ),
-    );
-
-    final holidayAccentColor = ref.watch(
-      settingsProvider.select((s) => s.value?.holidayAccentColorValue),
-    );
-
-    final myDutyGroup = ref.watch(
-      settingsProvider.select((s) => s.value?.myDutyGroup),
-    );
-
-    final holidaysAsyncValue = ref.watch(schoolHolidaysProvider);
-    final holidaysState = holidaysAsyncValue.whenData((data) => data).value;
-
+  Widget build(BuildContext context) {
+    final holidaysState = renderingData.holidaysState;
     final hasSchoolHoliday =
         holidaysState?.isEnabled == true &&
         holidaysState?.hasHolidayOnDate(day) == true;
@@ -144,67 +75,44 @@ class _MemoizedCalendarDayContent extends ConsumerWidget {
         : [];
     final schoolHolidayName = holidays.isNotEmpty ? holidays.first.name : null;
 
-    final String? effectiveMyGroup = computeEffectiveMyGroup(
-      preferredGroup: preferredGroup,
-      myDutyGroup: myDutyGroup,
-    );
+    final CalendarDayScheduleLookup? scheduleLookup =
+        renderingData.scheduleLookup;
+    final dutyData = scheduleLookup == null
+        ? const DutyData(
+            myDuty: '',
+            partnerDuty: '',
+            personalCalendarTitles: <String>[],
+          )
+        : _MemoizedDutyCalculator.calculateDutyData(
+            day: day,
+            scheduleLookup: scheduleLookup,
+            activeConfigName: renderingData.activeConfigName,
+            preferredGroup: renderingData.effectiveMyGroup,
+            partnerConfigName: renderingData.effectivePartnerConfigName,
+            partnerGroup: renderingData.effectivePartnerGroup,
+            activeDutyTypes: renderingData.activeDutyTypes,
+            partnerDutyTypes: renderingData.partnerDutyTypes,
+          );
 
-    final Map<String, DutyType>? activeDutyTypes = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.activeConfig?.dutyTypes,
-      ),
-    );
-    final List<DutyScheduleConfig> configs = ref.watch(
-      scheduleCoordinatorProvider.select(
-        (state) => state.value?.configs ?? const <DutyScheduleConfig>[],
-      ),
-    );
-    Map<String, DutyType>? partnerDutyTypes;
-    final String? partnerName = effectivePartnerConfigName;
-    if (partnerName != null && partnerName.isNotEmpty) {
-      for (final DutyScheduleConfig c in configs) {
-        if (c.name == partnerName) {
-          partnerDutyTypes = c.dutyTypes;
-          break;
-        }
-      }
-    }
-
-    final dutyData = _MemoizedDutyCalculator.calculateDutyData(
-      day: day,
-      scheduleLookup: scheduleLookup,
-      activeConfigName: activeConfig,
-      preferredGroup: effectiveMyGroup,
-      partnerConfigName: effectivePartnerConfigName,
-      partnerGroup: effectivePartnerGroup,
-      activeDutyTypes: activeDutyTypes,
-      partnerDutyTypes: partnerDutyTypes,
-    );
-
-    final isSelected = _isSelected(selectedDay);
+    final bool isSelected = dayType == CalendarDayType.selected;
 
     return AnimatedCalendarDay(
       day: day,
       dutyAbbreviation: dutyData.myDuty,
       partnerDutyAbbreviation: dutyData.partnerDuty,
       personalCalendarTitles: dutyData.personalCalendarTitles,
-      partnerAccentColorValue: partnerAccentColor,
-      myAccentColorValue: myAccentColor,
-      holidayAccentColorValue: holidayAccentColor,
+      partnerAccentColorValue: renderingData.partnerAccentColorValue,
+      myAccentColorValue: renderingData.myAccentColorValue,
+      holidayAccentColorValue: renderingData.holidayAccentColorValue,
       dayType: dayType,
       width: width ?? CalendarConfig.kCalendarDayWidth,
       height: height ?? CalendarConfig.kCalendarDayHeight,
       isSelected: isSelected,
+      useCompactDutyStripes: useCompactDutyStripes,
+      onTap: onDaySelected,
       hasSchoolHoliday: hasSchoolHoliday,
       schoolHolidayName: schoolHolidayName,
     );
-  }
-
-  bool _isSelected(DateTime? selectedDay) {
-    if (selectedDay == null) return false;
-    return day.year == selectedDay.year &&
-        day.month == selectedDay.month &&
-        day.day == selectedDay.day;
   }
 }
 

--- a/lib/presentation/widgets/screens/calendar/components/table_calendar.dart
+++ b/lib/presentation/widgets/screens/calendar/components/table_calendar.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:table_calendar/table_calendar.dart' as tc;
 import 'package:dienstplan/presentation/state/schedule/schedule_coordinator_notifier.dart';
 import 'package:dienstplan/presentation/widgets/screens/calendar/builders/calendar_day_builders.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart';
 import 'package:dienstplan/core/constants/calendar_config.dart';
 import 'package:dienstplan/presentation/widgets/screens/calendar/utils/calendar_layout_utils.dart';
 
@@ -20,17 +21,24 @@ class CalendarTable extends ConsumerWidget {
 
   final ValueChanged<DateTime> onPageChanged;
   final ValueChanged<DateTime> onDaySelected;
+  final bool useCompactDutyStripes;
 
   const CalendarTable({
     super.key,
     required this.onPageChanged,
     required this.onDaySelected,
+    required this.useCompactDutyStripes,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(scheduleCoordinatorProvider.select((s) => s.value));
-    final DateTime focusedDay = state?.focusedDay ?? DateTime.now();
+    final CalendarTableRenderingData tableData = ref.watch(
+      calendarTableRenderingDataProvider,
+    );
+    final CalendarDayRenderingData dayData = ref.watch(
+      calendarDayRenderingDataProvider,
+    );
+    final DateTime focusedDay = tableData.focusedDay;
     final int weekRows = getWeekRowsForMonth(
       focusedDay,
       starting: CalendarConfig.startingDayOfWeek,
@@ -44,7 +52,7 @@ class CalendarTable extends ConsumerWidget {
 
         final String stableCalendarKey = _calendarTableKey(
           focusedDay: focusedDay,
-          activeConfigName: state?.activeConfigName,
+          activeConfigName: tableData.activeConfigName,
           localeLanguageCode: Localizations.localeOf(context).languageCode,
           rowHeight: rowHeight,
         );
@@ -62,7 +70,7 @@ class CalendarTable extends ConsumerWidget {
             daysOfWeekHeight: CalendarConfig.kDaysOfWeekRowHeight,
             rowHeight: rowHeight,
             selectedDayPredicate: (day) {
-              return tc.isSameDay(state?.selectedDay, day);
+              return tc.isSameDay(tableData.selectedDay, day);
             },
             onDaySelected: (selectedDay, focusedDay) async {
               await ref
@@ -81,6 +89,8 @@ class CalendarTable extends ConsumerWidget {
             },
             calendarBuilders: CalendarDayBuilders.create(
               cellHeight: cellHeight,
+              renderingData: dayData,
+              useCompactDutyStripes: useCompactDutyStripes,
             ),
             calendarStyle: CalendarConfig.createCalendarStyle(context),
             headerStyle: CalendarConfig.createHeaderStyle(),

--- a/lib/presentation/widgets/screens/calendar/date_selector/animated_calendar_day.dart
+++ b/lib/presentation/widgets/screens/calendar/date_selector/animated_calendar_day.dart
@@ -17,6 +17,7 @@ class AnimatedCalendarDay extends StatefulWidget {
   final double? width;
   final double? height;
   final bool isSelected;
+  final bool useCompactDutyStripes;
   final VoidCallback? onTap;
   final bool hasSchoolHoliday;
   final String? schoolHolidayName;
@@ -34,6 +35,7 @@ class AnimatedCalendarDay extends StatefulWidget {
     this.width,
     this.height,
     required this.isSelected,
+    this.useCompactDutyStripes = false,
     this.onTap,
     this.hasSchoolHoliday = false,
     this.schoolHolidayName,
@@ -81,9 +83,7 @@ class _AnimatedCalendarDayState extends State<AnimatedCalendarDay> {
         widget.width ?? CalendarConfig.kCalendarDayWidth;
     final double effectiveHeight =
         widget.height ?? CalendarConfig.kCalendarDayHeight;
-    final bool compactCell =
-        effectiveHeight <=
-        CalendarConfig.kCalendarDayCompactDutyStripesMaxHeight;
+    final bool compactCell = widget.useCompactDutyStripes;
     final double cellRadius = calendarDayCellBorderRadius(compact: compactCell);
 
     return InkWell(

--- a/test/presentation/calendar_day_builders_test.dart
+++ b/test/presentation/calendar_day_builders_test.dart
@@ -1,0 +1,100 @@
+import 'package:dienstplan/presentation/widgets/screens/calendar/builders/calendar_day_builders.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/memoized_calendar_day.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/date_selector/animated_calendar_day.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('selected builder creates selected calendar day cell', (
+    WidgetTester tester,
+  ) async {
+    const renderingData = CalendarDayRenderingData(
+      scheduleLookup: null,
+      activeConfigName: null,
+      preferredDutyGroup: null,
+      myDutyGroup: null,
+      partnerConfigName: null,
+      partnerDutyGroup: null,
+      isPartnerVisible: false,
+      partnerAccentColorValue: null,
+      myAccentColorValue: null,
+      holidayAccentColorValue: null,
+      activeDutyTypes: null,
+      configs: [],
+      holidaysState: null,
+    );
+    final builders = CalendarDayBuilders.create(
+      cellHeight: 48,
+      renderingData: renderingData,
+      useCompactDutyStripes: false,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return builders.selectedBuilder!(
+                context,
+                DateTime(2026, 5, 4),
+                DateTime(2026, 5, 1),
+              )!;
+            },
+          ),
+        ),
+      ),
+    );
+
+    final widget = tester.widget<MemoizedCalendarDay>(
+      find.byType(MemoizedCalendarDay),
+    );
+    expect(widget.renderingData, same(renderingData));
+    expect(widget.day, DateTime(2026, 5, 4));
+    expect(widget.dayType, CalendarDayType.selected);
+    expect(widget.useCompactDutyStripes, isFalse);
+  });
+
+  testWidgets(
+    'full calendar can use chips below old compact height threshold',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: AnimatedCalendarDay(
+              day: DateTime(2026, 8, 1),
+              dayType: CalendarDayType.default_,
+              dutyAbbreviation: 'DG',
+              height: 94,
+              isSelected: false,
+              useCompactDutyStripes: false,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('DG'), findsOneWidget);
+    },
+  );
+
+  testWidgets('compact calendar uses stripes instead of duty chips', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: AnimatedCalendarDay(
+            day: DateTime(2026, 8, 1),
+            dayType: CalendarDayType.default_,
+            dutyAbbreviation: 'DG',
+            height: 120,
+            isSelected: false,
+            useCompactDutyStripes: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('DG'), findsNothing);
+  });
+}

--- a/test/presentation/calendar_table_key_test.dart
+++ b/test/presentation/calendar_table_key_test.dart
@@ -14,5 +14,16 @@ void main() {
         'cal_2026_5_main_de_rh72.0',
       );
     });
+
+    test('does not include selected day', () {
+      final String key = calendarTableKeyForTesting(
+        focusedDay: DateTime(2026, 5, 4),
+        activeConfigName: 'main',
+        localeLanguageCode: 'de',
+        rowHeight: 72.04,
+      );
+
+      expect(key, isNot(contains('2026-05-06')));
+    });
   });
 }

--- a/test/presentation/calendar_table_rendering_data_test.dart
+++ b/test/presentation/calendar_table_rendering_data_test.dart
@@ -1,0 +1,52 @@
+import 'package:dienstplan/domain/entities/duty_schedule_config.dart';
+import 'package:dienstplan/domain/entities/duty_type.dart';
+import 'package:dienstplan/presentation/widgets/screens/calendar/components/calendar_day_rendering_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CalendarDayRenderingData', () {
+    test('disables partner fields when partner visibility is false', () {
+      const data = CalendarDayRenderingData(
+        activeConfigName: 'main',
+        preferredDutyGroup: 'A',
+        myDutyGroup: 'A',
+        partnerConfigName: 'partner',
+        partnerDutyGroup: 'B',
+        isPartnerVisible: false,
+        partnerAccentColorValue: 0xff0000ff,
+        myAccentColorValue: 0xffff0000,
+        holidayAccentColorValue: 0xff00ff00,
+        activeDutyTypes: <String, DutyType>{},
+        configs: <DutyScheduleConfig>[],
+        holidaysState: null,
+        scheduleLookup: null,
+      );
+
+      expect(data.effectivePartnerConfigName, isNull);
+      expect(data.effectivePartnerGroup, isNull);
+      expect(data.effectiveMyGroup, 'A');
+    });
+
+    test('uses configured partner fields when partner visibility is true', () {
+      const data = CalendarDayRenderingData(
+        activeConfigName: 'main',
+        preferredDutyGroup: null,
+        myDutyGroup: 'A',
+        partnerConfigName: 'partner',
+        partnerDutyGroup: 'B',
+        isPartnerVisible: true,
+        partnerAccentColorValue: null,
+        myAccentColorValue: null,
+        holidayAccentColorValue: null,
+        activeDutyTypes: <String, DutyType>{},
+        configs: <DutyScheduleConfig>[],
+        holidaysState: null,
+        scheduleLookup: null,
+      );
+
+      expect(data.effectivePartnerConfigName, 'partner');
+      expect(data.effectivePartnerGroup, 'B');
+      expect(data.effectiveMyGroup, 'A');
+    });
+  });
+}


### PR DESCRIPTION
## Description
Fixes the calendar full-view rendering path so duty entries remain text chips even when a month has enough week rows to reduce the day-cell height. The root cause was that day cells switched to compact duty stripes based on measured height; six-week months could fall below that threshold in the normal calendar view. The compact stripe mode is now driven explicitly by the split calendar layout instead.

This also keeps the calendar rendering-data refactor in the PR: day cells receive precomputed rendering data instead of watching multiple providers individually, and regression tests cover the full-view chip behavior plus compact stripe behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
Not applicable.

## Additional Context
Validation:
- `flutter analyze` passed
- `flutter test` passed
- `flutter test test/presentation/calendar_day_builders_test.dart` passed
- `git diff --check` passed

Gradle checks requested by repo instructions:
- `./gradlew test` failed in `:flutter_local_notifications:testDebugUnitTest` with `IllegalArgumentException at ClassReader.java:200`
- `./gradlew build` failed on the same third-party plugin test
- `./gradlew spotlessApply` is not available in this Android Gradle project